### PR TITLE
vmware_dns_host: ensure we can set empty value

### DIFF
--- a/changelogs/fragments/66877-vmware_host_dns.yaml
+++ b/changelogs/fragments/66877-vmware_host_dns.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_host_dns can now set the following empty values, ``domain``, ``search_domains`` and ``dns_servers``.

--- a/plugins/modules/vmware_host_dns.py
+++ b/plugins/modules/vmware_host_dns.py
@@ -223,7 +223,7 @@ class VmwareHostDNS(PyVmomi):
                         else:
                             dns_config.hostName = instance.dnsConfig.hostName
 
-                        if self.search_domains:
+                        if self.search_domains is not None:
                             if instance.dnsConfig.searchDomain != self.search_domains:
                                 host_result['search_domains_previous'] = instance.dnsConfig.searchDomain
                                 host_result['search_domains_changed'] = (
@@ -252,7 +252,7 @@ class VmwareHostDNS(PyVmomi):
 
                             # Check domain
                             host_result['domain'] = self.domain
-                            if self.domain:
+                            if self.domain is not None:
                                 if instance.dnsConfig.domainName != self.domain:
                                     host_result['domain_previous'] = instance.dnsConfig.domainName
                                     changed = True
@@ -263,7 +263,7 @@ class VmwareHostDNS(PyVmomi):
 
                             # Check DNS server(s)
                             host_result['dns_servers'] = self.dns_servers
-                            if self.dns_servers:
+                            if self.dns_servers is not None:
                                 if instance.dnsConfig.address != self.dns_servers:
                                     host_result['dns_servers_previous'] = instance.dnsConfig.address
                                     host_result['dns_servers_changed'] = (
@@ -440,8 +440,8 @@ def main():
         device=dict(type='str'),
         host_name=dict(required=False, type='str'),
         domain=dict(required=False, type='str'),
-        dns_servers=dict(required=False, type='list'),
-        search_domains=dict(required=False, type='list'),
+        dns_servers=dict(required=False, type='list', default=None),
+        search_domains=dict(required=False, type='list', default=None),
         esxi_hostname=dict(required=False, type='str'),
         cluster_name=dict(required=False, type='str'),
         verbose=dict(type='bool', default=False, required=False)

--- a/tests/integration/targets/vmware_host_dns/tasks/static.yml
+++ b/tests/integration/targets/vmware_host_dns/tasks/static.yml
@@ -9,11 +9,7 @@
         validate_certs: False
         type: 'static'
         host_name: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['host_name'] }}"
-        domain: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['domain_name'] }}"
-        dns_servers: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['ip_address'] }}"
-        search_domains: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['search_domain'] }}"
       register: vmware_host_dns_result_0001
-
     - name: Ensure DNS config wasn't changed
       assert:
         that:
@@ -28,9 +24,6 @@
         validate_certs: False
         type: 'static'
         host_name: newname
-        domain: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['domain_name'] }}"
-        dns_servers: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['ip_address'] }}"
-        search_domains: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['search_domain'] }}"
       register: vmware_host_dns_result_0002
 
     - name: Ensure DNS config was changed
@@ -46,10 +39,7 @@
         password: '{{ esxi_password }}'
         validate_certs: False
         type: 'static'
-        host_name: newname
         domain: new.domain
-        dns_servers: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['ip_address'] }}"
-        search_domains: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['search_domain'] }}"
       register: vmware_host_dns_result_0003
 
     - name: Ensure DNS config was changed
@@ -65,12 +55,9 @@
         password: '{{ esxi_password }}'
         validate_certs: False
         type: 'static'
-        host_name: newname
-        domain: new.domain
         dns_servers:
           - 1.2.3.4
           - 5.6.7.8
-        search_domains: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['search_domain'] }}"
       register: vmware_host_dns_result_0004
 
     - name: Ensure DNS config was changed
@@ -86,11 +73,6 @@
         password: '{{ esxi_password }}'
         validate_certs: False
         type: 'static'
-        host_name: newname
-        domain: new.domain
-        dns_servers:
-          - 1.2.3.4
-          - 5.6.7.8
         search_domains:
           - subdomain.example.local
           - example.local
@@ -153,8 +135,6 @@
         validate_certs: False
         type: 'static'
         domain: new.domain
-        dns_servers: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['ip_address'] }}"
-        search_domains: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['search_domain'] }}"
       register: vmware_host_dns_result_0007
 
     - name: Ensure DNS config was changed
@@ -171,11 +151,9 @@
         cluster_name: "{{ ccr1 }}"
         validate_certs: False
         type: 'static'
-        domain: new.domain
         dns_servers:
           - 1.2.3.4
           - 5.6.7.8
-        search_domains: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['search_domain'] }}"
       register: vmware_host_dns_result_0008
 
     - name: Ensure DNS config was changed
@@ -192,10 +170,6 @@
         cluster_name: "{{ ccr1 }}"
         validate_certs: False
         type: 'static'
-        domain: new.domain
-        dns_servers:
-          - 1.2.3.4
-          - 5.6.7.8
         search_domains:
           - subdomain.example.local
           - example.local
@@ -205,6 +179,45 @@
       assert:
         that:
           - vmware_host_dns_result_0009 is changed
+
+    - name: Revert to original DNS configuration
+      include_tasks: teardown.yaml
+
+    - name: Remove all the DNS servers
+      vmware_host_dns:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        cluster_name: "{{ ccr1 }}"
+        validate_certs: False
+        type: 'static'
+        dns_servers: []
+      register: vmware_host_dns_result_0010
+
+    - name: Ensure DNS config was changed
+      assert:
+        that:
+          - vmware_host_dns_result_0010 is changed
+
+    - name: Remove the domain
+      vmware_host_dns:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        cluster_name: "{{ ccr1 }}"
+        validate_certs: False
+        type: 'static'
+        domain: ''
+      register: vmware_host_dns_result_0011
+
+    - name: Ensure the server has no domain
+      assert:
+        that:
+          - vmware_host_dns_result_0011 is changed
+
+
+    - name: Revert to original DNS configuration
+      include_tasks: teardown.yaml
 
   always:
     # Revert to original DNS configuration


### PR DESCRIPTION
Ensure we can set empty:

- search_domains list
- domain string
- dns_servers list

Also, extend and simplify the test-suite

See: https://github.com/ansible/ansible/pull/66877