### PR TITLE
vmware_guest: fix dns_suffix list

### DIFF
--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -1786,14 +1786,20 @@ class PyVmomiHelper(PyVmomi):
             globalip.dnsServerList = self.params['customization']['dns_servers']
 
         # TODO: Maybe list the different domains from the interfaces here by default ?
+        dns_suffixes = []
         if 'dns_suffix' in self.params['customization']:
             dns_suffix = self.params['customization']['dns_suffix']
-            if isinstance(dns_suffix, list):
-                globalip.dnsSuffixList = " ".join(dns_suffix)
-            else:
-                globalip.dnsSuffixList = dns_suffix
-        elif 'domain' in self.params['customization']:
-            globalip.dnsSuffixList = self.params['customization']['domain']
+            if dns_suffix:
+                if isinstance(dns_suffix, list):
+                    dns_suffixes += dns_suffix
+                else:
+                    dns_suffixes.append(dns_suffix)
+
+                globalip.dnsSuffixList = dns_suffixes
+
+        if 'domain' in self.params['customization']:
+            dns_suffixes.insert(0, self.params['customization']['domain'])
+            globalip.dnsSuffixList = dns_suffixes
 
         if self.params['guest_id']:
             guest_id = self.params['guest_id']


### PR DESCRIPTION
##### SUMMARY
Bugfix for supplying multiple dns_suffix enties, thay are configured incorrectly.
Also when a vm is provisioned to a domain the supplied dns_suffixes are ignored.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
vmware_guest

##### ADDITIONAL INFORMATION
Given the following input (clone from windows template)
```yaml

  vmware_guest:
...
    customization:
      domain: "{{ guest_domain }}"
      dns_servers:
        - 8.8.8.8
        - 9.9.9.9
      dns_suffix:
        - example.com
        - example2.com
```
The following DNS suffixes are configured
![afbeelding](https://user-images.githubusercontent.com/61044/73551199-425cd100-4446-11ea-9250-03f0eb6d8826.png)

Expected (after this PR):
![afbeelding](https://user-images.githubusercontent.com/61044/73551336-8059f500-4446-11ea-978a-8d75fb3a2bad.png)

Original PR: https://github.com/ansible/ansible/pull/66987