### PR TITLE
Not specify new disk filename

### DIFF
--- a/plugins/modules/vmware_guest_disk.py
+++ b/plugins/modules/vmware_guest_disk.py
@@ -485,13 +485,7 @@ class PyVmomiHelper(PyVmomi):
                 if disk['datastore_cluster'] is not None:
                     datastore_name = self.get_recommended_datastore(datastore_cluster_obj=disk['datastore_cluster'], disk_spec_obj=disk_spec)
                     disk['datastore'] = find_obj(self.content, [vim.Datastore], datastore_name)
-                if disk['filename'] is None:
-                    disk_spec.device.backing.fileName = "[%s] %s/%s_%s_%s.vmdk" % (
-                        disk['datastore'].name,
-                        vm_name, vm_name,
-                        str(scsi_controller),
-                        str(disk['disk_unit_number']))
-                else:
+                if disk['filename'] is not None:
                     disk_spec.device.backing.fileName = disk['filename']
                 disk_spec.device.backing.datastore = disk['datastore']
                 disk_spec = self.get_ioandshares_diskconfig(disk_spec, disk)

--- a/tests/integration/targets/vmware_guest_disk/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_disk/tasks/main.yml
@@ -230,3 +230,53 @@
   assert:
      that:
          - test_shares_IoLimits is changed
+
+- name: remove disks without destroy file
+  vmware_guest_disk:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 }}"
+    validate_certs: no
+    name: "{{ virtual_machines[0].name }}"
+    disk:
+        - state: "absent"
+          scsi_controller: 0
+          unit_number: 4
+          destroy: false
+  register: test_remove_without_destroy
+
+- debug:
+    msg: "{{ test_remove_without_destroy }}"
+
+- name: assert that changes were made
+  assert:
+    that:
+        - test_remove_without_destroy is changed
+
+- name: re-create disk with valid disk mode
+  vmware_guest_disk:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 }}"
+    validate_certs: no
+    name: "{{ virtual_machines[0].name }}"
+    disk:
+        - datastore: "{{ rw_datastore }}"
+          disk_mode: "persistent"
+          scsi_controller: 0
+          scsi_type: 'paravirtual'
+          size_gb: 1
+          state: present
+          type: eagerzeroedthick
+          unit_number: 4
+  register: test_recreate_disk
+
+- debug:
+    msg: "{{ test_recreate_disk }}"
+
+- name: assert that changes were made
+  assert:
+    that:
+        - test_recreate_disk is changed


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Not specify filename for new disk

if new disk filename is not specified, vmware esxi will set new disk
filename appending a not ever used number, so even recreate new disk with same controller number and same unit number, filename existence failure would not occur.

This change is to avoid of following issue.
```
msg:Failed to manage disks for virtual machine 'xxx' with exception : ('Cannot complete the operation because the file or folder /vmfs/volumes/yyy/xxx/xxx_1001_0.vmdk already exists'
```


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/cloud/vmware/vmware_guest_disk.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Add function test for this commit and test PASS.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
First remove one existing disk without destroy file from datastore, recreate it with same controller number and unit number, recreate would success with filename appending new never used number.

Original disk information:
There are 6 disks, disk filenames are following, disk "3" is on controller number "0", unit number "4", filename is [LocalDS_0] DC0_H0_VM0/DC0_H0_VM0_2.vmdk
"0"： "backing_filename": "[LocalDS_0] DC0_H0_VM0/disk1.vmdk"
"1"： "backing_filename": "[LocalDS_0] DC0_H0_VM0/DC0_H0_VM0.vmdk		"
"2"： "backing_filename": "[LocalDS_0] DC0_H0_VM0/DC0_H0_VM0_1.vmdk"
"3"： "backing_filename": "[LocalDS_0] DC0_H0_VM0/DC0_H0_VM0_2.vmdk"
   "controller_key": 1000
   "unit_number": 4
"4"： "backing_filename": "[LocalDS_0] DC0_H0_VM0/DC0_H0_VM0_3.vmdk"
"5"： "backing_filename": "[LocalDS_0] DC0_H0_VM0/DC0_H0_VM0_4.vmdk"

Step 1.  remove existing disk "3" on controller number '0' and unit number '4' without disk file from datastore.
```
- name: remove disks without destroy file
  vmware_guest_disk:
    hostname: "{{ vcenter_hostname }}"
    username: "{{ vcenter_username }}"
    password: "{{ vcenter_password }}"
    datacenter: "{{ dc1 }}"
    validate_certs: no
    name: "{{ virtual_machines[0].name }}"
    disk:
        - state: "absent"
          scsi_controller: 0
          unit_number: 4
          destroy: false
```

Step 2. recreate new disk on controller number '0' and unit number '4', recreate successfully, new filename is "[LocalDS_0] DC0_H0_VM0/DC0_H0_VM0_5.vmdk", which is new and never used before.
```
            "5": {
                "backing_datastore": "LocalDS_0",
                "backing_disk_mode": "persistent",
                "backing_eagerlyscrub": true,
                "backing_filename": "[LocalDS_0] DC0_H0_VM0/DC0_H0_VM0_5.vmdk",
                "backing_thinprovisioned": null,
                "backing_writethrough": null,
                "capacity_in_bytes": null,
                "capacity_in_kb": 1048576,
                "controller_key": 1000,
...
                "key": 207,
                "label": "disk-1000-4",
...
                "unit_number": 4
            }

```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
Original PR: https://github.com/ansible/ansible/pull/67600