### PR TITLE
mail params are not mandatory

### DIFF
--- a/plugins/modules/vmware_vcenter_settings.py
+++ b/plugins/modules/vmware_vcenter_settings.py
@@ -246,8 +246,9 @@ class VmwareVcenterSettings(PyVmomi):
         directory_query_limit_size = self.params['user_directory'].get('query_limit_size')
         directory_validation = self.params['user_directory'].get('validation')
         directory_validation_period = self.params['user_directory'].get('validation_period')
-        mail_server = self.params['mail'].get('server')
-        mail_sender = self.params['mail'].get('sender')
+        mail = self.params.get('mail') or {'mail': {'server': '', 'sender': ''}}
+        mail_server = mail.get('server', '')
+        mail_sender = mail.get('sender', '')
         snmp_receiver_1_url = self.params['snmp_receivers'].get('snmp_receiver_1_url')
         snmp_receiver_1_enabled = self.params['snmp_receivers'].get('snmp_receiver_1_enabled')
         snmp_receiver_1_port = self.params['snmp_receivers'].get('snmp_receiver_1_port')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In vcenter mail_server and mail_sender are optional and we don't use it in our company.
Additionally nobody knows how vcenter behaves internally when these params are set ;)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_vcenter_settings.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
changed: [vc-b-0.cc.qa-de-1.cloud.sap] => {
    "changed": true,
    "db_event_cleanup": true,
    "db_event_retention": 30,
    "db_max_connections": 50,
    "db_task_cleanup": true,
    "db_task_retention": 30,
    "directory_query_limit": true,
    "directory_query_limit_size": 5000,
    "directory_timeout": 60,
    "directory_validation": false,
    "directory_validation_period": 1440,
    "invocation": {
        "module_args": {
            "database": {
                "event_cleanup": true,
                "event_retention": 30,
                "max_connections": 50,
                "task_cleanup": true,
                "task_retention": 30
            },
            "hostname": "xxxxxxxxxxxxxxxxx",
            "logging_options": "info",
            "mail": null,
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "port": 443,
            "runtime_settings": {
                "managed_address": "xxxxxxxxxxxxxxxxx",
                "unique_id": 17,
                "vcenter_server_name": "xxxxxxxxxxxxxxxxxxx"
            },
            "snmp_receivers": {
                "snmp_receiver_1_community": "public",
                "snmp_receiver_1_enabled": true,
                "snmp_receiver_1_port": 162,
                "snmp_receiver_1_url": "localhost",
                "snmp_receiver_2_community": "",
                "snmp_receiver_2_enabled": false,
                "snmp_receiver_2_port": 162,
                "snmp_receiver_2_url": "",
                "snmp_receiver_3_community": "",
                "snmp_receiver_3_enabled": false,
                "snmp_receiver_3_port": 162,
                "snmp_receiver_3_url": "",
                "snmp_receiver_4_community": "",
                "snmp_receiver_4_enabled": false,
                "snmp_receiver_4_port": 162,
                "snmp_receiver_4_url": ""
            },
            "timeout_settings": {
                "long_operations": 120,
                "normal_operations": 30
            },
            "user_directory": {
                "query_limit": true,
                "query_limit_size": 5000,
                "timeout": 60,
                "validation": false,
                "validation_period": 1440
            },
            "username": "xxxxxxxxxxxxxxxxxx",
            "validate_certs": false
        }
    },
    "logging_options": "info",
    "mail_sender": "",
    "mail_sender_previous": "aaaaa@xxxxxxxxxxxxxxxxxx",
    "mail_server": "",
    "mail_server_previous": "xxxxxxxxxxxxxxxxx",
    "msg": "Mail sender and Mail server changed",
    "runtime_managed_address": "xxxxxxxxxxxxxxxxx",
    "runtime_server_name": "xxxxxxxxxxxxxxxxxxx",
    "runtime_unique_id": 17,
    "timeout_long_operations": 120,
    "timeout_normal_operations": 30
}
META: ran handlers
META: ran handlers

PLAY RECAP ***********************************************************************************************************************************************
xxxxxxxxxxxxxxxxx : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```

Original PR: https://github.com/ansible/ansible/pull/65348