### PR TITLE
added two spaces in variable

### DIFF
--- a/plugins/modules/vmware_guest_move.py
+++ b/plugins/modules/vmware_guest_move.py
@@ -111,7 +111,7 @@ EXAMPLES = r'''
     password: "{{ vcenter_password }}"
     validate_certs: no
     datacenter: "{{ datacenter }}"
-    folder: "/{{datacenter}}/vm"
+    folder: "/{{ datacenter }}/vm"
     name: "{{ vm_name }}"
   delegate_to: localhost
   register: vm_facts


### PR DESCRIPTION
According to https://github.com/ansible-collections/vmware/pull/20/commits/809d6e69fb385881b93d3e201954fbbf7bb60a31#r387436816

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
According to https://github.com/ansible-collections/vmware/pull/20/commits/809d6e69fb385881b93d3e201954fbbf7bb60a31#r387436816
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest_move

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
