### PR TITLE
Serialize non-json type objects in hostvars

### DIFF
--- a/changelogs/fragments/58-non-json-properties.yml
+++ b/changelogs/fragments/58-non-json-properties.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- In inventory plugin, serialize properties user specifies which are objects as dicts (https://github.com/ansible-collections/vmware/pull/58).

--- a/plugins/inventory/vmware_vm_inventory.py
+++ b/plugins/inventory/vmware_vm_inventory.py
@@ -216,7 +216,7 @@ class BaseVMwareInventory:
         Check requirements and do login
         """
         self.check_requirements()
-        _, self.content = self._login()
+        self.si, self.content = self._login()
         self.rest_content = self._login_vapi()
 
     def _login_vapi(self):

--- a/plugins/inventory/vmware_vm_inventory.py
+++ b/plugins/inventory/vmware_vm_inventory.py
@@ -168,6 +168,7 @@ EXAMPLES = r'''
 
 import ssl
 import atexit
+import json
 from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.utils.display import Display
 
@@ -314,6 +315,43 @@ class BaseVMwareInventory:
                                "the documentation for more information.")
 
     @staticmethod
+    def _process_object_types(vobj, level=0):
+        """For an object that is not a valid JSON type, loop over its properties
+        and return them in a dictionary"""
+        try:
+            json.dumps(vobj)
+            return vobj
+        except Exception:
+            rdata = {}
+            properties = dir(vobj)
+            properties = [str(x) for x in properties if not x.startswith('_')]
+            properties = [x for x in properties if x not in ('Array', 'disabledMethod', 'declaredAlarmState')]
+            properties = sorted(properties)
+
+            for prop in properties:
+                # Attempt to get the property, skip on fail
+                try:
+                    propToSerialize = getattr(vobj, prop)
+                except Exception:
+                    continue
+
+                if callable(propToSerialize):
+                    continue
+
+                prop = prop.lower()
+                if level + 1 <= 2:
+                    try:
+                        rdata[prop] = BaseVMwareInventory._process_object_types(
+                            propToSerialize,
+                            level=(level + 1)
+                        )
+                    except vim.fault.NoPermission:
+                        pass
+
+        return rdata
+
+
+    @staticmethod
     def _get_object_prop(vm, attributes):
         """Safely get a property or return None"""
         result = vm
@@ -322,6 +360,8 @@ class BaseVMwareInventory:
                 result = getattr(result, attribute)
             except (AttributeError, IndexError):
                 return None
+            # assure that result is valid JSON data
+            result = BaseVMwareInventory._process_object_types(result)
         return result
 
 


### PR DESCRIPTION
##### SUMMARY

Inventory files of the following type did not work:

```yaml
plugin: community.vmware.vmware_vm_inventory
properties:
- summary  # the problems
- storage
- runtime
- network
- guest
- datastore
- config
- capability
```

That is a regression from the old vmware script in the ansible/ansible "contrib" folder.

This fixes that.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
inventory

##### ADDITIONAL INFORMATION
The error that above inventories would give look like:

```
$ ANSIBLE_COLLECTIONS_PATHS=../../awx/plugins/collections/ ansible-inventory -i vmware_vm_inventory.yml --list --export -vvv
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under
development. This is a rapidly changing source of code and can become unstable at any point.
ansible-inventory 2.10.0.dev0
  config file = None
  configured module search path = ['/Users/alancoding/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/alancoding/Documents/repos/ansible/lib/ansible
  executable location = /Users/alancoding/.virtualenvs/awx_collection/bin/ansible-inventory
  python version = 3.6.5 (default, Apr 25 2018, 14:23:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.1)]
No config file found; using defaults
host_list declined parsing /Users/alancoding/Documents/tower/testing/awx_906_g8ztjsp3/vmware_vm_inventory.yml as it did not pass its verify_file() method
Parsed /Users/alancoding/Documents/tower/testing/awx_906_g8ztjsp3/vmware_vm_inventory.yml inventory source with auto plugin
ERROR! Unexpected Exception, this is probably a bug: Object of type 'vim.vm.Capability' is not JSON serializable
the full traceback was:

Traceback (most recent call last):
  File "/Users/alancoding/Documents/repos/ansible/bin/ansible-inventory", line 123, in <module>
    exit_code = cli.run()
  File "/Users/alancoding/Documents/repos/ansible/lib/ansible/cli/inventory.py", line 151, in run
    results = self.dump(results)
  File "/Users/alancoding/Documents/repos/ansible/lib/ansible/cli/inventory.py", line 185, in dump
    results = json.dumps(stuff, cls=AnsibleJSONEncoder, sort_keys=True, indent=4, preprocess_unsafe=True)
  File "/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
  File "/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/encoder.py", line 201, in encode
    chunks = list(chunks)
  File "/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/encoder.py", line 430, in _iterencode
    yield from _iterencode_dict(o, _current_indent_level)
  File "/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/encoder.py", line 404, in _iterencode_dict
    yield from chunks
  File "/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/encoder.py", line 404, in _iterencode_dict
    yield from chunks
  File "/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/encoder.py", line 404, in _iterencode_dict
    yield from chunks
  File "/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/encoder.py", line 437, in _iterencode
    o = _default(o)
  File "/Users/alancoding/Documents/repos/ansible/lib/ansible/module_utils/common/json.py", line 59, in default
    value = super(AnsibleJSONEncoder, self).default(o)
  File "/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/encoder.py", line 180, in default
    o.__class__.__name__)
TypeError: Object of type 'vim.vm.Capability' is not JSON serializable
```

The code structure here is not exactly the same as the script, but it is heavily influenced by it.