### PR TITLE
vmware_host_active_directory: Fail for unrecoverable AD problems

### DIFF
--- a/changelogs/fragments/59_vmware_host_active_directory.yml
+++ b/changelogs/fragments/59_vmware_host_active_directory.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- vmware_host_active_directory: Fail when there are unrecoverable problems with AD membership instead of reporting a change that doesn't take place (https://github.com/ansible-collections/vmware/issues/59).

--- a/plugins/modules/vmware_host_active_directory.py
+++ b/plugins/modules/vmware_host_active_directory.py
@@ -162,14 +162,13 @@ class VmwareHostAdAuthentication(PyVmomi):
                         results['result'][host.name]['membership_state'] = active_directory_info.domainMembershipStatus
                         results['result'][host.name]['joined_domain'] = active_directory_info.joinedDomain
                         results['result'][host.name]['trusted_domains'] = active_directory_info.trustedDomain
-                        msg = "Host is joined to AD domain, but "
+                        msg = host.name + " is joined to AD domain, but "
                         if active_directory_info.domainMembershipStatus == 'clientTrustBroken':
                             msg += "the client side of the trust relationship is broken"
                         elif active_directory_info.domainMembershipStatus == 'inconsistentTrust':
                             msg += "unexpected domain controller responded"
                         elif active_directory_info.domainMembershipStatus == 'noServers':
-                            msg += "the host thinks it's part of a domain and " \
-                                "no domain controllers could be reached to confirm"
+                            msg += "no domain controllers could be reached to confirm"
                         elif active_directory_info.domainMembershipStatus == 'serverTrustBroken':
                             msg += "the server side of the trust relationship is broken (or bad machine password)"
                         elif active_directory_info.domainMembershipStatus == 'otherProblem':
@@ -177,6 +176,7 @@ class VmwareHostAdAuthentication(PyVmomi):
                         elif active_directory_info.domainMembershipStatus == 'unknown':
                             msg += "the Active Directory integration provider does not support domain trust checks"
                         results['result'][host.name]['msg'] = msg
+                        self.module.fail_json(msg=msg)
                 # Enable and join AD domain
                 else:
                     if self.module.check_mode:


### PR DESCRIPTION
##### SUMMARY
Fail when there's a problem with the domain membership of a host instead of reporting a change that doesn't take place.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_host_active_directory

##### ADDITIONAL INFORMATION
Fixes #59 
