### PR TITLE
vmware_dvswitch - set 6.5.0 as the default version

### DIFF
--- a/changelogs/fragments/vmware_dvswitch_default_version.yaml
+++ b/changelogs/fragments/vmware_dvswitch_default_version.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- vmware_dvswitch - set ``6.5.0`` as the default value of the ``version`` field. Since vSphere 7.0.0, the field cannot be undefined.

--- a/plugins/modules/vmware_dvswitch.py
+++ b/plugins/modules/vmware_dvswitch.py
@@ -690,7 +690,7 @@ def main():
             switch_version=dict(
                 choices=['5.0.0', '5.1.0', '5.5.0', '6.0.0', '6.5.0', '6.6.0'],
                 aliases=['version'],
-                default=None
+                default='6.5.0'
             ),
             uplink_quantity=dict(type='int'),
             uplink_prefix=dict(type='str', default='Uplink '),


### PR DESCRIPTION
Since vSphere 7.0.0, the field cannot be undefined. By setting a default
value, we should avoid any breakage of the user playbook.