### PR TITLE
setup_dvswitch: bump switch_version to 6.5.0

### DIFF
--- a/tests/integration/targets/prepare_vmware_tests/tasks/setup_dvswitch.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/setup_dvswitch.yml
@@ -3,7 +3,7 @@
   vmware_dvswitch:
     datacenter_name: '{{ dc1 }}'
     switch_name: '{{ dvswitch1 }}'
-    switch_version: 6.0.0
+    switch_version: 6.5.0
     mtu: 9000
     uplink_quantity: 2
     discovery_proto: lldp


### PR DESCRIPTION
vCenter 7.0.0 does not accept 6.0.0 anymore.