### PR TITLE
Added private vlan configuration in vmware_dvs_portgroup

### DIFF
--- a/changelogs/fragments/pvlan-config-vmware-dvs-portgroup.yml
+++ b/changelogs/fragments/pvlan-config-vmware-dvs-portgroup.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- vmware_dvs_portgroup - Added support for distributed port group with private VLAN.

--- a/plugins/modules/vmware_dvs_portgroup.py
+++ b/plugins/modules/vmware_dvs_portgroup.py
@@ -45,6 +45,7 @@ options:
             - The VLAN ID that should be configured with the portgroup, use 0 for no VLAN.
             - 'If C(vlan_trunk) is configured to be I(true), this can be a combination of multiple ranges and numbers, example: 1-200, 205, 400-4094.'
             - The valid C(vlan_id) range is from 0 to 4094. Overlapping ranges are allowed.
+            - 'If C(vlan_private) is configured to be I(true), the corresponding private VLAN should already be configured in the distributed vSwitch.'
         required: True
         type: str
     num_ports:
@@ -72,6 +73,14 @@ options:
     vlan_trunk:
         description:
             - Indicates whether this is a VLAN trunk or not.
+            - Mutually exclusive with C(vlan_private) parameter.
+        required: False
+        default: False
+        type: bool
+    vlan_private:
+        description:
+            - Indicates whether this is for a private VLAN or not.
+            - Mutually exclusive with C(vlan_trunk) parameter.
         required: False
         default: False
         type: bool
@@ -166,6 +175,20 @@ EXAMPLES = '''
     switch_name: dvSwitch
     vlan_id: 1-1000, 1005, 1100-1200
     vlan_trunk: True
+    num_ports: 120
+    portgroup_type: earlyBinding
+    state: present
+  delegate_to: localhost
+
+- name: Create private vlan portgroup
+  vmware_dvs_portgroup:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    portgroup_name: private-vlan-portrgoup
+    switch_name: dvSwitch
+    vlan_id: 1001
+    vlan_private: True
     num_ports: 120
     portgroup_type: earlyBinding
     state: present
@@ -275,6 +298,16 @@ class VMwareDvsPortgroup(PyVmomi):
         if self.module.params['vlan_trunk']:
             config.defaultPortConfig.vlan = vim.dvs.VmwareDistributedVirtualSwitch.TrunkVlanSpec()
             config.defaultPortConfig.vlan.vlanId = list(map(lambda x: vim.NumericRange(start=x[0], end=x[1]), self.create_vlan_list()))
+        elif self.module.params['vlan_private']:
+            # Check that private VLAN exists in dvs
+            if self.module.params['vlan_private']:
+                pvlan_exists = self.check_dvs_pvlan()
+                if not pvlan_exists:
+                    self.module.fail_json(msg="No private vlan with id %s in distributed vSwitch %s"
+                                          % (self.module.params['vlan_id'], self.module.params['switch_name']))
+
+            config.defaultPortConfig.vlan = vim.dvs.VmwareDistributedVirtualSwitch.PvlanSpec()
+            config.defaultPortConfig.vlan.pvlanId = int(self.module.params['vlan_id'])
         else:
             config.defaultPortConfig.vlan = vim.dvs.VmwareDistributedVirtualSwitch.VlanIdSpec()
             config.defaultPortConfig.vlan.vlanId = int(self.module.params['vlan_id'])
@@ -373,6 +406,14 @@ class VMwareDvsPortgroup(PyVmomi):
             changed, result = self.create_port_group()
         self.module.exit_json(changed=changed, result=str(result))
 
+    def check_dvs_pvlan(self):
+        for pvlan in self.dv_switch.config.pvlanConfig:
+            if pvlan.primaryVlanId == int(self.module.params['vlan_id']):
+                return True
+            if pvlan.secondaryVlanId == int(self.module.params['vlan_id']):
+                return True
+        return False
+
     def check_dvspg_state(self):
         self.dv_switch = find_dvs_by_name(self.content, self.module.params['switch_name'])
 
@@ -394,6 +435,11 @@ class VMwareDvsPortgroup(PyVmomi):
             if not isinstance(defaultPortConfig.vlan, vim.dvs.VmwareDistributedVirtualSwitch.TrunkVlanSpec):
                 return 'update'
             if map(lambda x: (x.start, x.end), defaultPortConfig.vlan.vlanId) != self.create_vlan_list():
+                return 'update'
+        elif self.module.params['vlan_private']:
+            if not isinstance(defaultPortConfig.vlan, vim.dvs.VmwareDistributedVirtualSwitch.PvlanSpec):
+                return 'update'
+            if defaultPortConfig.vlan.pvlanId != int(self.module.params['vlan_id']):
                 return 'update'
         else:
             if not isinstance(defaultPortConfig.vlan, vim.dvs.VmwareDistributedVirtualSwitch.VlanIdSpec):
@@ -447,6 +493,7 @@ def main():
             portgroup_type=dict(required=True, choices=['earlyBinding', 'lateBinding', 'ephemeral'], type='str'),
             state=dict(required=True, choices=['present', 'absent'], type='str'),
             vlan_trunk=dict(type='bool', default=False),
+            vlan_private=dict(type='bool', default=False),
             network_policy=dict(
                 type='dict',
                 options=dict(
@@ -517,6 +564,9 @@ def main():
     )
 
     module = AnsibleModule(argument_spec=argument_spec,
+                           mutually_exclusive=[
+                               ['vlan_trunk', 'vlan_private']
+                           ],
                            supports_check_mode=True)
 
     vmware_dvs_portgroup = VMwareDvsPortgroup(module)

--- a/tests/integration/targets/vmware_dvs_portgroup/tasks/main.yml
+++ b/tests/integration/targets/vmware_dvs_portgroup/tasks/main.yml
@@ -385,3 +385,126 @@
   assert:
     that:
         - dvs_pg_result_0017.changed
+
+- name: Check fail for missing PVLAN in dvs
+  vmware_dvs_portgroup:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    portgroup_name: private-vlan-portgroup
+    switch_name: "{{ dvswitch1 }}"
+    vlan_id: 10
+    vlan_private: True
+    num_ports: 12
+    portgroup_type: earlyBinding
+    state: present
+    validate_certs: false
+  register: dvs_pg_result_0018
+  ignore_errors: True
+
+- name: Ensure module fails for missing private VLAN in dvs
+  assert:
+    that:
+        - not dvs_pg_result_0018.changed
+        - "'No private vlan with id 10 in distributed vSwitch {{ dvswitch1 }}' == '{{ dvs_pg_result_0018.msg }}'"
+
+- when: vcsim is not defined
+  block:
+    - name: add distributed vSwitch
+      vmware_dvswitch:
+        validate_certs: False
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter_name: "{{ dc1 }}"
+        state: present
+        switch_name: dvswitch_0001
+        mtu: 9000
+        uplink_quantity: 2
+        discovery_proto: lldp
+        discovery_operation: both
+      register: dvs_result_0001
+
+    - name: ensure distributed vswitch is present
+      assert:
+        that:
+            - dvs_result_0001 is changed
+
+    - name: Configure PVLANs to test PVLAN dpg
+      vmware_dvswitch_pvlans:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        switch: dvswitch_0001
+        primary_pvlans:
+          - primary_pvlan_id: 1
+        secondary_pvlans:
+          - primary_pvlan_id: 1
+            secondary_pvlan_id: 2
+            pvlan_type: isolated
+        validate_certs: false
+      register: pvlans_result
+
+    - name: ensure pvlans were configured
+      assert:
+        that:
+          - pvlans_result is not failed
+
+    - name: Create private vlan portgroup
+      vmware_dvs_portgroup:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        portgroup_name: private-vlan-portgroup
+        switch_name: dvswitch_0001
+        vlan_id: 1
+        vlan_private: True
+        num_ports: 12
+        portgroup_type: earlyBinding
+        state: present
+        validate_certs: false
+      register: dvs_pg_result_0019
+
+    - name: ensure dvs portgroup with pvlan is present
+      assert:
+        that:
+            - dvs_pg_result_0019.changed
+
+    - name: Change private vlan id
+      vmware_dvs_portgroup:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        portgroup_name: private-vlan-portgroup
+        switch_name: dvswitch_0001
+        vlan_id: 2
+        vlan_private: True
+        num_ports: 12
+        portgroup_type: earlyBinding
+        state: present
+        validate_certs: false
+      register: dvs_pg_result_0020
+
+    - name: ensure dvs portgroup pvlan id is changed
+      assert:
+        that:
+            - dvs_pg_result_0020.changed
+
+    - name: Change private vlan to basic vlan portgroup
+      vmware_dvs_portgroup:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        portgroup_name: private-vlan-portgroup
+        switch_name: dvswitch_0001
+        vlan_id: 5
+        num_ports: 12
+        portgroup_type: earlyBinding
+        state: present
+        validate_certs: false
+      register: dvs_pg_result_0021
+
+    - name: ensure dvs portgroup type changed
+      assert:
+        that:
+            - dvs_pg_result_0021.changed

--- a/tests/integration/targets/vmware_dvs_portgroup/tasks/main.yml
+++ b/tests/integration/targets/vmware_dvs_portgroup/tasks/main.yml
@@ -508,3 +508,14 @@
       assert:
         that:
             - dvs_pg_result_0021.changed
+  always:
+    - name: delete distributed vSwitch
+      vmware_dvswitch:
+        validate_certs: False
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter_name: "{{ dc1 }}"
+        state: absent
+        switch_name: dvswitch_0001
+      register: dvs_result_0001


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/vmware/pull/250

##### SUMMARY
Added support for creating a distributed port group with a private VLAN.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/vmware_dvs_portgroup.py

##### ADDITIONAL INFORMATION
Tested on vSphere 6.7
