### PR TITLE
tox: linters env only install flake8

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,12 @@ envlist = linters
 skipsdist = True
 
 [testenv]
-deps = -r{toxinidir}/requirements.txt
-       -r{toxinidir}/test-requirements.txt
+#deps = -r{toxinidir}/requirements.txt
+#       -r{toxinidir}/test-requirements.txt
 
 [testenv:linters]
 install_command = pip install {opts} {packages}
+deps = flake8
 commands =
   flake8 plugins {posargs}
 


### PR DESCRIPTION
No need to pull the army of dependencies of the VMware modules, if at
the end, we just need flake8.