### PR TITLE
tox: venv env should install Ansible

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,9 @@ commands =
   flake8 plugins {posargs}
 
 [testenv:venv]
+# This env is used to push new release on Galaxy
+install_command = pip install {opts} {packages}
+deps = ansible
 commands = {posargs}
 
 [flake8]


### PR DESCRIPTION
`build-ansible-collection` uses `.tox/venv/bin/ansible-galaxy` to
prepare and push the release.