### PR TITLE
Remove link to non-existing documentation

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -13,6 +13,5 @@ tags:
   - virtualization
 dependencies: {}
 repository: git@github.com:ansible-collections/vmware.git
-documentation: https://github.com/ansible-collections/vmware/tree/master/docs
 homepage: https://github.com/ansible-collections/vmware
 issues: https://github.com/ansible-collections/vmware/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc


### PR DESCRIPTION
##### SUMMARY
Remove link to non-existing documentation from `galaxy.yml`.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
galaxy.yml

##### ADDITIONAL INFORMATION
Fixes #74 
