### PR TITLE
re-enable vmware_guest_network test

### DIFF
--- a/tests/integration/targets/vmware_guest_network/aliases
+++ b/tests/integration/targets/vmware_guest_network/aliases
@@ -2,6 +2,4 @@ cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi_with_nested
-# until we figure out why vmware_guest_tools_wait fails in the CI
-disabled
 zuul/vmware/govcsim


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/413

The new lighter ISO image speed up the test a lot, this should be
enough to avoid the timeout problem. For instance, here a run goes from
7.1m to 4.4m.