### PR TITLE
prepare_vmware_tests: isolate the 'VM Network'

### DIFF
--- a/tests/integration/targets/prepare_vmware_tests/tasks/setup_attach_hosts.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/setup_attach_hosts.yml
@@ -18,13 +18,27 @@
     state: absent
   with_items: "{{ esxi_hosts }}"
 
-- name: Add Management Network VM Portgroup
-  vmware_portgroup:
+# A bit of explanation here. Our test VMs will produce some ARP traffic,
+# if we keep the "VM Network" on vSwitch0, the VM MAC address will
+# be visible by the external switch port. Depending on the
+# antispoofing policy in place, the switch may just decide to block
+# the port.
+- name: Add an isolated VMware vSwitch
+  vmware_vswitch:
     hostname: '{{ item }}'
     username: '{{ esxi_user }}'
     password: '{{ esxi_password }}'
-    esxi_hostname: 'item'
-    switch: "vSwitch0"
+    switch: isolated_vSwitch
+  with_items: "{{ esxi_hosts }}"
+
+- name: Add Management Network VM Portgroup
+  vmware_portgroup:
+    esxi_hostname: '{{ esxi_hosts }}'
+    switch: isolated_vSwitch
     portgroup: VM Network
     validate_certs: no
-  with_items: "{{ esxi_hosts }}"
+  register: _vm_network_portgroup
+  until: _vm_network_portgroup is succeeded
+  retries: 10
+  delay: 1
+  failed_when: _vm_network_portgroup is failure

--- a/tests/integration/targets/prepare_vmware_tests/tasks/teardown_with_esxi.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/teardown_with_esxi.yml
@@ -56,6 +56,26 @@
     - dvswitch_0002
   ignore_errors: yes
 
+- name: Clean up the VM Network portgroup
+  vmware_portgroup:
+    esxi_hostname: '{{ esxi_hosts }}'
+    switch: isolated_vSwitch
+    portgroup: VM Network
+    state: absent
+  ignore_errors: true
+  with_items:
+  - isolated_vSwitch
+  - vSwitch0
+
+- name: Remove any potential existing "VM Network" on vSwitch0
+  vmware_portgroup:
+    esxi_hostname: '{{ esxi_hosts }}'
+    switch: vSwitch0
+    portgroup: VM Network
+    validate_certs: no
+    state: absent
+  ignore_errors: yes
+
 - name: Remove the vSwitches
   vmware_vswitch:
     hostname: '{{ item }}'


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/410

Our test VMs will produce some ARP traffic, if we keep the "VM Network" on vSwitch0, the VM MAC address will be visible by the external switch port.
Depending on the antispoofing policy in place, the switch may just decide to block the port.
