### PR TITLE
remove the version key from galaxy.yml

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,10 +1,14 @@
+---
 namespace: community
 name: vmware
-version: 0.2.0
+# the version key is generated during the release by Zuul
+# https://github.com/ansible-network/releases/tree/master/ansible_releases/cmd
+# A script based on https://pypi.org/project/pbr/ will generate the version
+# key. The version value depends on the tag or the last git tag.
 readme: README.md
 authors:
   - Ansible (https://github.com/ansible)
-description: null
+description:
 license: GPL-3.0-or-later
 license_file: COPYING
 tags:


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/401

The version is generated during the release pipeline by:
https://github.com/ansible-network/releases/tree/master/ansible_releases/cmd/generate_ansible_collection.py