### PR TITLE
VMware: add new vmware module vmware_dvswitch_info

### DIFF
--- a/plugins/modules/vmware_dvswitch_info.py
+++ b/plugins/modules/vmware_dvswitch_info.py
@@ -124,7 +124,7 @@ EXAMPLES = '''
 RETURN = '''
 distributed_virtual_switches:
     description: list of dictionary of dvswitch and their information
-    returned: success
+    returned: always
     type: list
     sample:
       [
@@ -207,14 +207,11 @@ class VMwareDvSwitchInfoManager(PyVmomi):
         else:
             self.switch_objs = find_obj(self.content, [vim.DistributedVirtualSwitch], '', first=False)
 
-        if not self.switch_objs:
-            if self.switch_name:
-                self.module.fail_json(msg="Distributed Virtual Switch %s not found" % self.switch_name)
-            else:
-                self.module.fail_json(msg="Distributed Virtual Switch not found")
-
     def all_info(self):
         distributed_virtual_switches = []
+        if not self.switch_objs:
+            self.module.exit_json(changed=False, distributed_virtual_switches=distributed_virtual_switches)
+
         for switch_obj in self.switch_objs:
             pvlans = []
             if switch_obj.config.pvlanConfig:

--- a/plugins/modules/vmware_dvswitch_info.py
+++ b/plugins/modules/vmware_dvswitch_info.py
@@ -1,0 +1,313 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020, sky-joker
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: vmware_dvswitch_info
+short_description: Gathers info dvswitch configurations
+description:
+    - This module can be used to gather information about dvswitch configurations.
+author:
+    - sky-joker (@sky-joker)
+requirements:
+    - "python >= 2.7"
+    - PyVmomi
+options:
+    folder:
+      description:
+        - Specify a folder location of dvswitch to gather information from.
+        - 'Examples:'
+        - '   folder: /datacenter1/network'
+        - '   folder: datacenter1/network'
+        - '   folder: /datacenter1/network/folder1'
+        - '   folder: datacenter1/network/folder1'
+        - '   folder: /folder1/datacenter1/network'
+        - '   folder: folder1/datacenter1/network'
+        - '   folder: /folder1/datacenter1/network/folder2'
+      required: False
+      type: str
+    switch_name:
+      description:
+        - Name of a dvswitch to look for.
+        - If C(switch_name) not specified gather all dvswitch information.
+      aliases: ['switch', 'dvswitch']
+      required: False
+      type: str
+    schema:
+      description:
+        - Specify the output schema desired.
+        - The 'summary' output schema is the legacy output from the module
+        - The 'vsphere' output schema is the vSphere API class definition
+          which requires pyvmomi>6.7.1
+      choices: ['summary', 'vsphere']
+      default: 'summary'
+      type: str
+    properties:
+      description:
+        - Specify the properties to retrieve.
+        - If not specified, all properties are retrieved (deeply).
+        - Results are returned in a structure identical to the vsphere API.
+        - 'Example:'
+        - '   properties: ['
+        - '      "summary.name",'
+        - '      "summary.numPorts",'
+        - '      "config.maxMtu",'
+        - '      "overallStatus"'
+        - '   ]'
+        - Only valid when C(schema) is C(vsphere).
+      type: list
+      elements: str
+      required: False
+extends_documentation_fragment:
+    - community.vmware.vmware.documentation
+'''
+
+EXAMPLES = '''
+- name: Gather all registered dvswitch
+  community.vmware.vmware_dvswitch_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
+  delegate_to: localhost
+  register: dvswitch_info
+
+- name: Gather info about specific dvswitch
+  community.vmware.vmware_dvswitch_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
+    switch_name: DVSwitch01
+  delegate_to: localhost
+  register: dvswitch_info
+
+- name: Gather info from folder about specific dvswitch
+  community.vmware.vmware_dvswitch_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
+    folder: /datacenter1/network/F01
+    switch_name: DVSwitch02
+  delegate_to: localhost
+  register: dvswitch_info
+
+- name: Gather some info from a dvswitch using the vSphere API output schema
+  community.vmware.vmware_dvswitch_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
+    schema: vsphere
+    properties:
+      - summary.name
+      - summary.numPorts
+      - config.maxMtu
+      - overallStatus
+    switch_name: DVSwitch01
+  register: dvswitch_info
+'''
+
+RETURN = '''
+distributed_virtual_switches:
+    description: list of dictionary of dvswitch and their information
+    returned: success
+    type: list
+    sample:
+      [
+        {
+          "configure": {
+            "folder": "network",
+            "hosts": [
+              "esxi-test-02.local",
+              "esxi-test-01.local"
+            ],
+            "settings": {
+              "healthCheck": {
+                "TeamingHealthCheckConfig": false,
+                "VlanMtuHealthCheckConfig": false
+              },
+              "netflow": {
+                "activeFlowTimeout": 60,
+                "collectorIpAddress": "",
+                "collectorPort": 0,
+                "idleFlowTimeout": 15,
+                "internalFlowsOnly": false,
+                "observationDomainId": 0,
+                "samplingRate": 0,
+                "switchIpAddress": null
+              },
+              "properties": {
+                "administratorContact": {
+                  "contact": null,
+                  "name": null
+                },
+                "advanced": {
+                  "maxMtu": 1500,
+                  "multicastFilteringMode": "legacyFiltering"
+                },
+                "discoveryProtocol": {
+                  "operation": "listen",
+                  "protocol": "cdp"
+                },
+                "general": {
+                  "ioControl": true,
+                  "name": "DVSwitch01",
+                  "numPorts": 10,
+                  "numUplinks": 1,
+                  "vendor": "VMware, Inc.",
+                  "version": "6.6.0"
+                }
+              },
+              "privateVlan": []
+            }
+          }
+        }
+      ]
+'''
+
+try:
+    from pyVmomi import vim
+except ImportError:
+    pass
+
+from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec, find_obj, find_object_by_name
+from ansible.module_utils.basic import AnsibleModule
+
+
+class VMwareDvSwitchInfoManager(PyVmomi):
+    def __init__(self, module):
+        super(VMwareDvSwitchInfoManager, self).__init__(module)
+        self.folder = self.params['folder']
+        self.switch_name = self.params['switch_name']
+
+        folder_obj = None
+        if self.folder:
+            folder_obj = self.content.searchIndex.FindByInventoryPath(self.folder)
+            if not folder_obj:
+                self.module.fail_json(msg="Failed to find folder specified by %s" % self.folder)
+
+        if self.switch_name:
+            self.switch_objs = [find_object_by_name(self.content, self.switch_name, vim.DistributedVirtualSwitch, folder_obj)]
+            if None in self.switch_objs:
+                self.switch_objs = None
+        else:
+            self.switch_objs = find_obj(self.content, [vim.DistributedVirtualSwitch], '', first=False)
+
+        if not self.switch_objs:
+            if self.switch_name:
+                self.module.fail_json(msg="Distributed Virtual Switch %s not found" % self.switch_name)
+            else:
+                self.module.fail_json(msg="Distributed Virtual Switch not found")
+
+    def all_info(self):
+        distributed_virtual_switches = []
+        for switch_obj in self.switch_objs:
+            pvlans = []
+            if switch_obj.config.pvlanConfig:
+                for vlan in switch_obj.config.pvlanConfig:
+                    pvlans.append({
+                        'primaryVlanId': vlan.primaryVlanId,
+                        'secondaryVlanId': vlan.secondaryVlanId,
+                        'pvlanType': vlan.pvlanType
+                    })
+
+            host_members = []
+            if switch_obj.summary.hostMember:
+                for host in switch_obj.summary.hostMember:
+                    host_members.append(host.name)
+
+            health_check = {}
+            for health_config in switch_obj.config.healthCheckConfig:
+                if isinstance(health_config, vim.dvs.VmwareDistributedVirtualSwitch.VlanMtuHealthCheckConfig):
+                    health_check['VlanMtuHealthCheckConfig'] = health_config.enable
+                elif isinstance(health_config, vim.dvs.VmwareDistributedVirtualSwitch.TeamingHealthCheckConfig):
+                    health_check['TeamingHealthCheckConfig'] = health_config.enable
+
+            distributed_virtual_switches.append({
+                'configure': {
+                    'settings': {
+                        'properties': {
+                            'general': {
+                                'name': switch_obj.name,
+                                'vendor': switch_obj.config.productInfo.vendor,
+                                'version': switch_obj.config.productInfo.version,
+                                'numUplinks': len(switch_obj.config.uplinkPortPolicy.uplinkPortName),
+                                'numPorts': switch_obj.summary.numPorts,
+                                'ioControl': switch_obj.config.networkResourceManagementEnabled,
+                            },
+                            'advanced': {
+                                'maxMtu': switch_obj.config.maxMtu,
+                                'multicastFilteringMode': switch_obj.config.multicastFilteringMode,
+                            },
+                            'discoveryProtocol': {
+                                'protocol': switch_obj.config.linkDiscoveryProtocolConfig.protocol,
+                                'operation': switch_obj.config.linkDiscoveryProtocolConfig.operation,
+                            },
+                            'administratorContact': {
+                                'name': switch_obj.config.contact.name,
+                                'contact': switch_obj.config.contact.contact
+                            }
+                        },
+                        'privateVlan': pvlans,
+                        'netflow': {
+                            'switchIpAddress': switch_obj.config.switchIpAddress,
+                            'collectorIpAddress': switch_obj.config.ipfixConfig.collectorIpAddress,
+                            'collectorPort': switch_obj.config.ipfixConfig.collectorPort,
+                            'observationDomainId': switch_obj.config.ipfixConfig.observationDomainId,
+                            'activeFlowTimeout': switch_obj.config.ipfixConfig.activeFlowTimeout,
+                            'idleFlowTimeout': switch_obj.config.ipfixConfig.idleFlowTimeout,
+                            'samplingRate': switch_obj.config.ipfixConfig.samplingRate,
+                            'internalFlowsOnly': switch_obj.config.ipfixConfig.internalFlowsOnly
+                        },
+                        'healthCheck': health_check
+                    },
+                    'hosts': host_members,
+                    'folder': switch_obj.parent.name
+                }
+            })
+
+        self.module.exit_json(changed=False, distributed_virtual_switches=distributed_virtual_switches)
+
+    def properties_facts(self):
+        distributed_virtual_switches = []
+        for switch_obj in self.switch_objs:
+            distributed_virtual_switches.append(self.to_json(switch_obj, self.params.get('properties')))
+
+        self.module.exit_json(changed=False, distributed_virtual_switches=distributed_virtual_switches)
+
+
+def main():
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(
+        folder=dict(type='str', required=False),
+        switch_name=dict(type='str', required=False, aliases=['switch', 'dvswitch']),
+        schema=dict(type='str', choices=['summary', 'vsphere'], default='summary'),
+        properties=dict(type='list', required=False, elements='str')
+    )
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    vmware_dvswitch_info_mgr = VMwareDvSwitchInfoManager(module)
+
+    if module.params['schema'] == 'summary':
+        vmware_dvswitch_info_mgr.all_info()
+    else:
+        vmware_dvswitch_info_mgr.properties_facts()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/vmware_dvswitch_info/aliases
+++ b/tests/integration/targets/vmware_dvswitch_info/aliases
@@ -1,0 +1,4 @@
+shippable/vcenter/group1
+cloud/vcenter
+needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/tests/integration/targets/vmware_dvswitch_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_dvswitch_info/tasks/main.yml
@@ -161,3 +161,16 @@
       - info_dvswitches_with_properties_result.distributed_virtual_switches.0.name is defined
       - info_dvswitches_with_properties_result.distributed_virtual_switches.0.summary.numPorts is defined
       - info_dvswitches_with_properties_result.distributed_virtual_switches.0.config.maxMtu is defined
+
+- name: get list of when not exist the dvswitch
+  vmware_dvswitch_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
+    switch_name: "not_exist_the_dvswitch"
+  register: info_dvswitches_result
+
+- assert:
+    that:
+      - info_dvswitches_result.distributed_virtual_switches | length == 0

--- a/tests/integration/targets/vmware_dvswitch_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_dvswitch_info/tasks/main.yml
@@ -1,0 +1,163 @@
+# Test code for the vmware_dvswitch_info module.
+# Copyright: (c) 2020, sky-joker <sky.jokerxx@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_datacenter: true
+
+- name: add distributed vSwitch
+  vmware_dvswitch:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
+    datacenter_name: "{{ dc1 }}"
+    switch_name: "{{ dvswitch1 }}"
+    mtu: 9000
+    uplink_quantity: 2
+    discovery_proto: lldp
+    discovery_operation: both
+    state: present
+  register: add_distributed_vswitch_result
+
+- assert:
+    that:
+      - add_distributed_vswitch_result.changed
+
+- name: get list of info about dvswitches - check_mode is enabled
+  vmware_dvswitch_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
+    switch_name: "{{ dvswitch1 }}"
+  check_mode: yes
+  register: info_dvswitches_result
+
+- debug: var=info_dvswitches_result
+
+- assert:
+    that:
+      - info_dvswitches_result.distributed_virtual_switches.0.configure.folder is defined
+      - info_dvswitches_result.distributed_virtual_switches.0.configure.hosts is defined
+      - info_dvswitches_result.distributed_virtual_switches.0.configure.settings is defined
+
+- name: get list of info about dvswitches
+  vmware_dvswitch_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
+    switch_name: "{{ dvswitch1 }}"
+  register: info_dvswitches_result
+
+- debug: var=info_dvswitches_result
+
+- assert:
+    that:
+      - info_dvswitches_result.distributed_virtual_switches.0.configure.folder is defined
+      - info_dvswitches_result.distributed_virtual_switches.0.configure.hosts is defined
+      - info_dvswitches_result.distributed_virtual_switches.0.configure.settings is defined
+
+- name: get list of info about dvswitches - add folder param
+  vmware_dvswitch_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
+    folder: "{{ dc1 }}/network"
+    switch_name: "{{ dvswitch1 }}"
+  register: info_dvswitches_result
+
+- debug: var=info_dvswitches_result
+
+- assert:
+    that:
+      - info_dvswitches_result.distributed_virtual_switches.0.configure.folder is defined
+      - info_dvswitches_result.distributed_virtual_switches.0.configure.hosts is defined
+      - info_dvswitches_result.distributed_virtual_switches.0.configure.settings is defined
+
+- name: get list of info about one dvswitches with properties specify
+  vmware_dvswitch_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
+    switch_name: "{{ dvswitch1 }}"
+    schema: vsphere
+    properties:
+      - name
+  register: info_dvswitches_with_properties_result
+
+- debug: var=info_dvswitches_with_properties_result
+
+- assert:
+    that:
+      - info_dvswitches_with_properties_result.distributed_virtual_switches.0.name is defined
+      - info_dvswitches_with_properties_result.distributed_virtual_switches.0.name == dvswitch1
+
+- name: get list of info about one dvswitches with properties specify - add folder param
+  vmware_dvswitch_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
+    folder: "{{ dc1 }}/network"
+    switch_name: "{{ dvswitch1 }}"
+    schema: vsphere
+    properties:
+      - name
+  register: info_dvswitches_with_properties_result
+
+- debug: var=info_dvswitches_with_properties_result
+
+- assert:
+    that:
+      - info_dvswitches_with_properties_result.distributed_virtual_switches.0.name is defined
+
+- name: get list of info about dvswitches with multiple properties specify
+  vmware_dvswitch_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
+    switch_name: "{{ dvswitch1 }}"
+    schema: vsphere
+    properties:
+      - name
+      - summary.numPorts
+      - config.maxMtu
+  register: info_dvswitches_with_properties_result
+
+- debug: var=info_dvswitches_with_properties_result
+
+- assert:
+    that:
+      - info_dvswitches_with_properties_result.distributed_virtual_switches.0.name is defined
+      - info_dvswitches_with_properties_result.distributed_virtual_switches.0.summary.numPorts is defined
+      - info_dvswitches_with_properties_result.distributed_virtual_switches.0.config.maxMtu is defined
+
+- name: get list of info about dvswitches with multiple properties specify - add folder param
+  vmware_dvswitch_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
+    folder: "{{ dc1 }}/network"
+    switch_name: "{{ dvswitch1 }}"
+    schema: vsphere
+    properties:
+      - name
+      - summary.numPorts
+      - config.maxMtu
+  register: info_dvswitches_with_properties_result
+
+- debug: var=info_dvswitches_with_properties_result
+
+- assert:
+    that:
+      - info_dvswitches_with_properties_result.distributed_virtual_switches.0.name is defined
+      - info_dvswitches_with_properties_result.distributed_virtual_switches.0.summary.numPorts is defined
+      - info_dvswitches_with_properties_result.distributed_virtual_switches.0.config.maxMtu is defined

--- a/tests/integration/targets/vmware_dvswitch_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_dvswitch_info/tasks/main.yml
@@ -44,6 +44,23 @@
       - info_dvswitches_result.distributed_virtual_switches.0.configure.hosts is defined
       - info_dvswitches_result.distributed_virtual_switches.0.configure.settings is defined
 
+- name: get list of info about all dvswitches
+  vmware_dvswitch_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
+  register: info_dvswitches_result
+
+- debug: var=info_dvswitches_result
+
+- assert:
+    that:
+      - info_dvswitches_result.distributed_virtual_switches | length == 1
+      - info_dvswitches_result.distributed_virtual_switches.0.configure.folder is defined
+      - info_dvswitches_result.distributed_virtual_switches.0.configure.hosts is defined
+      - info_dvswitches_result.distributed_virtual_switches.0.configure.settings is defined
+
 - name: get list of info about dvswitches
   vmware_dvswitch_info:
     hostname: "{{ vcenter_hostname }}"
@@ -161,6 +178,33 @@
       - info_dvswitches_with_properties_result.distributed_virtual_switches.0.name is defined
       - info_dvswitches_with_properties_result.distributed_virtual_switches.0.summary.numPorts is defined
       - info_dvswitches_with_properties_result.distributed_virtual_switches.0.config.maxMtu is defined
+
+- name: delete distributed vSwitch
+  vmware_dvswitch:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
+    datacenter_name: "{{ dc1 }}"
+    switch_name: "{{ dvswitch1 }}"
+    state: absent
+  register: delete_distributed_vswitch_result
+
+- assert:
+    that:
+      - delete_distributed_vswitch_result.changed
+
+- name: get list of info about all dvswitches
+  vmware_dvswitch_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
+  register: info_dvswitches_result
+
+- assert:
+    that:
+      - info_dvswitches_result.distributed_virtual_switches | length == 0
 
 - name: get list of when not exist the dvswitch
   vmware_dvswitch_info:


### PR DESCRIPTION
##### SUMMARY

This PR adds a module that retrieves information about the dvswitch.
It can use this module to create reports from the jinja2 template or check the settings for dvswitch.

##### ISSUE TYPE

- New Module Pull Request

##### COMPONENT NAME

vmware_dvswitch_info

##### ADDITIONAL INFORMATION

tested with vCenter 6.7 and 7.0
