### PR TITLE
zuul: define govcsim target

### DIFF
--- a/tests/integration/targets/inventory_vmware_vm_inventory/aliases
+++ b/tests/integration/targets/inventory_vmware_vm_inventory/aliases
@@ -1,3 +1,4 @@
 shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
+zuul/vmware/govcsim

--- a/tests/integration/targets/vcenter_folder/aliases
+++ b/tests/integration/targets/vcenter_folder/aliases
@@ -1,3 +1,4 @@
 shippable/vcenter/group1
 cloud/vcenter
 zuul/vmware/vcenter_only
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_about_info/aliases
+++ b/tests/integration/targets/vmware_about_info/aliases
@@ -2,3 +2,4 @@ shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_cluster/aliases
+++ b/tests/integration/targets/vmware_cluster/aliases
@@ -2,3 +2,4 @@ shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_cluster_drs/aliases
+++ b/tests/integration/targets/vmware_cluster_drs/aliases
@@ -2,3 +2,4 @@ shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_cluster_ha/aliases
+++ b/tests/integration/targets/vmware_cluster_ha/aliases
@@ -2,3 +2,4 @@ shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_cluster_info/aliases
+++ b/tests/integration/targets/vmware_cluster_info/aliases
@@ -2,3 +2,4 @@ shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_cluster_vsan/aliases
+++ b/tests/integration/targets/vmware_cluster_vsan/aliases
@@ -2,3 +2,4 @@ shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_content_library_manager/aliases
+++ b/tests/integration/targets/vmware_content_library_manager/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_datacenter/aliases
+++ b/tests/integration/targets/vmware_datacenter/aliases
@@ -2,3 +2,4 @@ shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_datastore_cluster/aliases
+++ b/tests/integration/targets/vmware_datastore_cluster/aliases
@@ -2,3 +2,4 @@ shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_datastore_info/aliases
+++ b/tests/integration/targets/vmware_datastore_info/aliases
@@ -2,3 +2,4 @@ shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_datastore_maintenancemode/aliases
+++ b/tests/integration/targets/vmware_datastore_maintenancemode/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_drs_group/aliases
+++ b/tests/integration/targets/vmware_drs_group/aliases
@@ -2,3 +2,4 @@ shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_drs_group_info/aliases
+++ b/tests/integration/targets/vmware_drs_group_info/aliases
@@ -2,3 +2,4 @@ shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_drs_rule_info/aliases
+++ b/tests/integration/targets/vmware_drs_rule_info/aliases
@@ -2,3 +2,4 @@ shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_dvs_portgroup/aliases
+++ b/tests/integration/targets/vmware_dvs_portgroup/aliases
@@ -2,3 +2,4 @@ shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_dvs_portgroup_find/aliases
+++ b/tests/integration/targets/vmware_dvs_portgroup_find/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_dvs_portgroup_info/aliases
+++ b/tests/integration/targets/vmware_dvs_portgroup_info/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_dvswitch/aliases
+++ b/tests/integration/targets/vmware_dvswitch/aliases
@@ -2,3 +2,4 @@ shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_dvswitch_nioc/aliases
+++ b/tests/integration/targets/vmware_dvswitch_nioc/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_dvswitch_pvlans/aliases
+++ b/tests/integration/targets/vmware_dvswitch_pvlans/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_dvswitch_uplink_pg/aliases
+++ b/tests/integration/targets/vmware_dvswitch_uplink_pg/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_folder_info/aliases
+++ b/tests/integration/targets/vmware_folder_info/aliases
@@ -2,3 +2,4 @@ shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest/aliases
+++ b/tests/integration/targets/vmware_guest/aliases
@@ -2,3 +2,4 @@ shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_boot_info/aliases
+++ b/tests/integration/targets/vmware_guest_boot_info/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_controller/aliases
+++ b/tests/integration/targets/vmware_guest_controller/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_cross_vc_clone/aliases
+++ b/tests/integration/targets/vmware_guest_cross_vc_clone/aliases
@@ -1,3 +1,4 @@
 cloud/vcenter
 unsupported
 needs/target/prepare_vmware_tests
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_custom_attribute_defs/aliases
+++ b/tests/integration/targets/vmware_guest_custom_attribute_defs/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_custom_attributes/aliases
+++ b/tests/integration/targets/vmware_guest_custom_attributes/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_customization_info/aliases
+++ b/tests/integration/targets/vmware_guest_customization_info/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_disk/aliases
+++ b/tests/integration/targets/vmware_guest_disk/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_disk_info/aliases
+++ b/tests/integration/targets/vmware_guest_disk_info/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_find/aliases
+++ b/tests/integration/targets/vmware_guest_find/aliases
@@ -2,3 +2,4 @@ shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_info/aliases
+++ b/tests/integration/targets/vmware_guest_info/aliases
@@ -2,3 +2,4 @@ shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_move/aliases
+++ b/tests/integration/targets/vmware_guest_move/aliases
@@ -2,3 +2,4 @@ shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_network/aliases
+++ b/tests/integration/targets/vmware_guest_network/aliases
@@ -4,3 +4,4 @@ needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
 # until we figure out why vmware_guest_tools_wait fails in the CI
 disabled
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_powerstate/aliases
+++ b/tests/integration/targets/vmware_guest_powerstate/aliases
@@ -2,3 +2,4 @@ shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_screenshot/aliases
+++ b/tests/integration/targets/vmware_guest_screenshot/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_sendkey/aliases
+++ b/tests/integration/targets/vmware_guest_sendkey/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_serial_port/aliases
+++ b/tests/integration/targets/vmware_guest_serial_port/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_snapshot/aliases
+++ b/tests/integration/targets/vmware_guest_snapshot/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_snapshot_info/aliases
+++ b/tests/integration/targets/vmware_guest_snapshot_info/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_tools_info/aliases
+++ b/tests/integration/targets/vmware_guest_tools_info/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_host/aliases
+++ b/tests/integration/targets/vmware_host/aliases
@@ -2,3 +2,4 @@ shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_2esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_host_config_info/aliases
+++ b/tests/integration/targets/vmware_host_config_info/aliases
@@ -2,3 +2,4 @@ shippable/vcenter/group2
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_host_config_manager/aliases
+++ b/tests/integration/targets/vmware_host_config_manager/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_host_dns_info/aliases
+++ b/tests/integration/targets/vmware_host_dns_info/aliases
@@ -3,3 +3,4 @@ cloud/vcenter
 
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_host_feature_info/aliases
+++ b/tests/integration/targets/vmware_host_feature_info/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_host_firewall_info/aliases
+++ b/tests/integration/targets/vmware_host_firewall_info/aliases
@@ -3,3 +3,4 @@ cloud/vcenter
 
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_host_hyperthreading/aliases
+++ b/tests/integration/targets/vmware_host_hyperthreading/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_host_kernel_manager/aliases
+++ b/tests/integration/targets/vmware_host_kernel_manager/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_host_powerstate/aliases
+++ b/tests/integration/targets/vmware_host_powerstate/aliases
@@ -1,3 +1,4 @@
 cloud/vcenter
 shippable/vcenter/group2
 needs/target/prepare_vmware_tests
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_host_service_info/aliases
+++ b/tests/integration/targets/vmware_host_service_info/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_host_snmp/aliases
+++ b/tests/integration/targets/vmware_host_snmp/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_host_ssl_info/aliases
+++ b/tests/integration/targets/vmware_host_ssl_info/aliases
@@ -2,3 +2,4 @@ shippable/vcenter/group2
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_host_vmnic_info/aliases
+++ b/tests/integration/targets/vmware_host_vmnic_info/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_local_role_info/aliases
+++ b/tests/integration/targets/vmware_local_role_info/aliases
@@ -2,3 +2,4 @@ shippable/vcenter/group2
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_local_role_manager/aliases
+++ b/tests/integration/targets/vmware_local_role_manager/aliases
@@ -2,3 +2,4 @@ shippable/vcenter/group2
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_local_user_manager/aliases
+++ b/tests/integration/targets/vmware_local_user_manager/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_maintenancemode/aliases
+++ b/tests/integration/targets/vmware_maintenancemode/aliases
@@ -2,3 +2,4 @@ shippable/vcenter/group2
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_portgroup/aliases
+++ b/tests/integration/targets/vmware_portgroup/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_portgroup_info/aliases
+++ b/tests/integration/targets/vmware_portgroup_info/aliases
@@ -3,3 +3,4 @@ cloud/vcenter
 
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_resource_pool/aliases
+++ b/tests/integration/targets/vmware_resource_pool/aliases
@@ -2,3 +2,4 @@ shippable/vcenter/group2
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_resource_pool_info/aliases
+++ b/tests/integration/targets/vmware_resource_pool_info/aliases
@@ -2,3 +2,4 @@ shippable/vcenter/group2
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_tag_manager/aliases
+++ b/tests/integration/targets/vmware_tag_manager/aliases
@@ -1,3 +1,4 @@
 cloud/vcenter
 unsupported
 zuul/vmware/vcenter_only
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_target_canonical_info/aliases
+++ b/tests/integration/targets/vmware_target_canonical_info/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_vcenter_settings/aliases
+++ b/tests/integration/targets/vmware_vcenter_settings/aliases
@@ -2,3 +2,4 @@ shippable/vcenter/group2
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_vcenter_statistics/aliases
+++ b/tests/integration/targets/vmware_vcenter_statistics/aliases
@@ -2,3 +2,4 @@ shippable/vcenter/group2
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_vm_host_drs_rule/aliases
+++ b/tests/integration/targets/vmware_vm_host_drs_rule/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_vm_info/aliases
+++ b/tests/integration/targets/vmware_vm_info/aliases
@@ -3,3 +3,4 @@ shippable/vcenter/smoketest
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_vm_storage_policy_info/aliases
+++ b/tests/integration/targets/vmware_vm_storage_policy_info/aliases
@@ -2,3 +2,4 @@ shippable/vcenter/group2
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_vmotion/aliases
+++ b/tests/integration/targets/vmware_vmotion/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_2esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_vsan_health_info/aliases
+++ b/tests/integration/targets/vmware_vsan_health_info/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 unsupported
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_vspan_session/aliases
+++ b/tests/integration/targets/vmware_vspan_session/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_vswitch/aliases
+++ b/tests/integration/targets/vmware_vswitch/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_2esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_vswitch_info/aliases
+++ b/tests/integration/targets/vmware_vswitch_info/aliases
@@ -2,3 +2,4 @@ cloud/vcenter
 shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vsphere_file/aliases
+++ b/tests/integration/targets/vsphere_file/aliases
@@ -1,1 +1,2 @@
 unsupported
+zuul/vmware/govcsim


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/406
Depends-On: https://github.com/ansible-collections/vmware/pull/102

This target will be used to identify which role can be run with govcsim.
