### PR TITLE
vmware_guest_tools_wait: reenable the test

### DIFF
--- a/tests/integration/targets/vmware_guest_tools_wait/aliases
+++ b/tests/integration/targets/vmware_guest_tools_wait/aliases
@@ -2,5 +2,3 @@ shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi_with_nested
-# the test fails randomly in the CI
-disabled


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/vmware/pull/90

The problem was probably caused by an L2 Antispoofing policy.