### PR TITLE
Update Hardware version to include 15 - 6.7U2

### DIFF
--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -1332,7 +1332,7 @@ class PyVmomiHelper(PyVmomi):
 
                     if hw_version_check_failed:
                         self.module.fail_json(msg="Failed to set hardware.version '%s' value as valid"
-                                              " values range from 3 (ESX 2.x) to 14 (ESXi 6.5 and greater)." % temp_version)
+                                              " values range from 3 (ESX 2.x) to 15 (ESXi 6.7U2 and greater)." % temp_version)
                     # Hardware version is denoted as "vmx-10"
                     version = "vmx-%02d" % temp_version
                     self.configspec.version = version


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/406

##### SUMMARY
Bounds for hardware version template did not include the latest versions released under the 6.7 train of vSphere. Update to include up to version 15 and update error message for versioning outside of bounds.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest.py

##### ADDITIONAL INFORMATION

