### PR TITLE
vmware_host_service_manager: disable the test-suite

### DIFF
--- a/tests/integration/targets/vmware_host_service_manager/aliases
+++ b/tests/integration/targets/vmware_host_service_manager/aliases
@@ -2,3 +2,5 @@ cloud/vcenter
 shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+# see: https://github.com/ansible-collections/vmware/issues/101
+disabled


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/406

Temporarily disable `vmware_host_service_manager` tests. This until the
test-suite is fixed.

See: https://github.com/ansible-collections/vmware/issues/101