### PR TITLE
define vcenter_1esxi_with_nested alias

### DIFF
--- a/tests/integration/targets/vmware_export_ovf/tasks/main.yml
+++ b/tests/integration/targets/vmware_export_ovf/tasks/main.yml
@@ -18,15 +18,6 @@
       setup_datastore: true
       setup_virtualmachines: true
 
-  - name: set state to poweroff on the tested VM
-    vmware_guest:
-      validate_certs: False
-      hostname: "{{ vcenter_hostname }}"
-      username: "{{ vcenter_username }}"
-      password: "{{ vcenter_password }}"
-      name: "{{ virtual_machines_in_cluster[0].name }}"
-      state: poweredoff
-
   - name: export VM to ovf template
     vmware_export_ovf:
       validate_certs: False

--- a/tests/integration/targets/vmware_guest/aliases
+++ b/tests/integration/targets/vmware_guest/aliases
@@ -2,4 +2,5 @@ shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+zuul/vmware/vcenter_1esxi_with_nested
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_disk_facts/aliases
+++ b/tests/integration/targets/vmware_guest_disk_facts/aliases
@@ -1,4 +1,4 @@
 cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_1esxi
+zuul/vmware/vcenter_1esxi_with_nested

--- a/tests/integration/targets/vmware_guest_disk_info/aliases
+++ b/tests/integration/targets/vmware_guest_disk_info/aliases
@@ -1,5 +1,5 @@
 cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_1esxi
+zuul/vmware/vcenter_1esxi_with_nested
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_network/aliases
+++ b/tests/integration/targets/vmware_guest_network/aliases
@@ -1,7 +1,7 @@
 cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_1esxi
+zuul/vmware/vcenter_1esxi_with_nested
 # until we figure out why vmware_guest_tools_wait fails in the CI
 disabled
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_powerstate/aliases
+++ b/tests/integration/targets/vmware_guest_powerstate/aliases
@@ -1,5 +1,5 @@
 shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_1esxi
+zuul/vmware/vcenter_1esxi_with_nested
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_screenshot/aliases
+++ b/tests/integration/targets/vmware_guest_screenshot/aliases
@@ -1,5 +1,5 @@
 cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_1esxi
+zuul/vmware/vcenter_1esxi_with_nested
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_sendkey/aliases
+++ b/tests/integration/targets/vmware_guest_sendkey/aliases
@@ -1,5 +1,5 @@
 cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_1esxi
+zuul/vmware/vcenter_1esxi_with_nest
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_tools_wait/aliases
+++ b/tests/integration/targets/vmware_guest_tools_wait/aliases
@@ -1,6 +1,6 @@
 shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_1esxi
+zuul/vmware/vcenter_1esxi_with_nested
 # the test fails randomly in the CI
 disabled


### PR DESCRIPTION
This alias include all the test roles that start nested VM.