### PR TITLE
vmware_vm_inventory: use vcenter_1esxi_with_nested alias

### DIFF
--- a/tests/integration/targets/vmware_vm_inventory/aliases
+++ b/tests/integration/targets/vmware_vm_inventory/aliases
@@ -1,3 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
-zuul/vmware/vcenter_2esxi
+zuul/vmware/vcenter_1esxi_with_nested


### PR DESCRIPTION
The test creates and starts some VM. This is why it should use an ESXi
that support nested virt.