### PR TITLE
VMware: add new vmware module vmware_host_logbundle_info

### DIFF
--- a/changelogs/fragments/110-vmware_host_logbundle_info.yml
+++ b/changelogs/fragments/110-vmware_host_logbundle_info.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_host_logbundle_info - new code module for a new feature for getting manifests  for ESXi support log bundle

--- a/plugins/modules/vmware_host_logbundle_info.py
+++ b/plugins/modules/vmware_host_logbundle_info.py
@@ -36,7 +36,7 @@ extends_documentation_fragment:
 
 EXAMPLES = '''
 - name: fetch the manifests for logbundle from ESXi
-  vmware_host_logbundle_info:
+  community.vmware.vmware_host_logbundle_info:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"

--- a/plugins/modules/vmware_host_logbundle_info.py
+++ b/plugins/modules/vmware_host_logbundle_info.py
@@ -18,7 +18,7 @@ DOCUMENTATION = '''
 module: vmware_host_logbundle_info
 short_description: Gathers manifest info for logbundle
 description:
-    - This module can be used to gather manifest infomation for logbundle.
+    - This module can be used to gather manifest information for logbundle from ESXi.
 author:
     - sky-joker (@sky-joker)
 requirements:
@@ -43,8 +43,6 @@ EXAMPLES = '''
     validate_certs: no
     esxi_hostname: "{{ esxi_hostname }}"
   register: fetch_manifests_result
-
-- debug: var=fetch_manifests_result
 '''
 
 RETURN = '''

--- a/plugins/modules/vmware_host_logbundle_info.py
+++ b/plugins/modules/vmware_host_logbundle_info.py
@@ -1,0 +1,153 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020, sky-joker
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: vmware_host_logbundle_info
+short_description: Gathers manifest info for logbundle
+description:
+    - This module can be used to gather manifest infomation for logbundle.
+author:
+    - sky-joker (@sky-joker)
+requirements:
+    - "python >= 2.7"
+    - PyVmomi
+options:
+    esxi_hostname:
+      description:
+        - Name of the host system to fetch the manifests for logbundle.
+      type: str
+      required: True
+extends_documentation_fragment:
+    - community.vmware.vmware.documentation
+'''
+
+EXAMPLES = '''
+- name: fetch the manifests for logbundle from ESXi
+  vmware_host_logbundle_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
+    esxi_hostname: "{{ esxi_hostname }}"
+  register: fetch_manifests_result
+
+- debug: var=fetch_manifests_result
+'''
+
+RETURN = '''
+manifests:
+    description: list of dictionary of manifest information for logbundle
+    returned: always
+    type: list
+    sample:
+      [
+        {
+          "enabled": "true",
+          "group": "System",
+          "id": "System:Base",
+          "name": "Base",
+          "vmOnly": "false"
+        },
+        {
+          "enabled": "false",
+          "group": "System",
+          "id": "System:BaseMinmal",
+          "name": "BaseMinmal",
+          "vmOnly": "false"
+        },
+        {
+          "enabled": "true",
+          "group": "Fcd",
+          "id": "Fcd:Catalog",
+          "name": "Catalog",
+          "vmOnly": "false"
+        },
+        {
+          "enabled": "false",
+          "group": "VirtualMachines",
+          "id": "VirtualMachines:CoreDumpHung",
+          "name": "CoreDumpHung",
+          "vmOnly": "true"
+        },
+        {
+          "enabled": "true",
+          "group": "System",
+          "id": "System:CoreDumps",
+          "name": "CoreDumps",
+          "vmOnly": "false"
+        }
+      ]
+'''
+
+try:
+    from pyVmomi import vim
+except ImportError:
+    pass
+
+from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.urls import Request
+from ansible.module_utils.urls import fetch_url
+import xml.etree.ElementTree as ET
+
+
+class VMwareHostLogbundleInfo(PyVmomi):
+    def __init__(self, module):
+        super(VMwareHostLogbundleInfo, self).__init__(module)
+        self.esxi_hostname = self.params['esxi_hostname']
+
+    def generate_req_headers(self, url):
+        # get ticket
+        req = vim.SessionManager.HttpServiceRequestSpec(method='httpGet', url=url)
+        ticket = self.content.sessionManager.AcquireGenericServiceTicket(req)
+
+        headers = {
+            'Content-Type': 'application/octet-stream',
+            'Cookie': 'vmware_cgi_ticket=%s' % ticket.id
+        }
+
+        return headers
+
+    def get_listmanifests(self):
+        url = 'https://' + self.esxi_hostname + '/cgi-bin/vm-support.cgi?listmanifests=1'
+        headers = self.generate_req_headers(url)
+
+        try:
+            resp, info = fetch_url(self.module, method='GET', headers=headers, url=url)
+            manifest_list = ET.fromstring(resp.read())
+            manifests = []
+            for manifest in manifest_list[0]:
+                manifests.append(manifest.attrib)
+
+            self.module.exit_json(changed=False, manifests=manifests)
+        except Exception as e:
+            self.module.fail_json(msg="Failed to fetch manifests from %s: %s" % (url, e))
+
+
+def main():
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(
+        esxi_hostname=dict(type='str', required=True)
+    )
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    vmware_host_logbundle_info_mgr = VMwareHostLogbundleInfo(module)
+    vmware_host_logbundle_info_mgr.get_listmanifests()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/vmware_host_logbundle_info.py
+++ b/plugins/modules/vmware_host_logbundle_info.py
@@ -99,7 +99,6 @@ except ImportError:
 
 from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.urls import Request
 from ansible.module_utils.urls import fetch_url
 import xml.etree.ElementTree as ET
 

--- a/tests/integration/targets/vmware_host_logbundle_info/aliases
+++ b/tests/integration/targets/vmware_host_logbundle_info/aliases
@@ -1,0 +1,4 @@
+shippable/vcenter/group1
+cloud/vcenter
+needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_host_logbundle_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_logbundle_info/tasks/main.yml
@@ -1,0 +1,38 @@
+# Test code for the vmware_host_logbundle_info module.
+# Copyright: (c) 2020, sky-joker <sky.jokerxx@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+
+- name: fetch the manifests for logbundle from ESXi - connect to vCenter
+  vmware_host_logbundle_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
+    esxi_hostname: "{{ esxi1 }}"
+  register: fetch_manifests_result
+
+- debug: var=fetch_manifests_result.manifests
+
+- assert:
+    that:
+      - fetch_manifests_result.manifests | length >= 1
+
+- name: fetch the manifests for logbundle from ESXi - connect to ESXi
+  vmware_host_logbundle_info:
+    hostname: "{{ esxi1 }}"
+    username: "{{ esxi_user }}"
+    password: "{{ esxi_password }}"
+    validate_certs: no
+    esxi_hostname: "{{ esxi1 }}"
+  register: fetch_manifests_result
+
+- debug: var=fetch_manifests_result.manifests
+
+- assert:
+    that:
+      - fetch_manifests_result.manifests | length >= 1


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/vmware/pull/122

##### SUMMARY

This PR adds a module that fetches manifests for logbundle from ESXi.
In this module that can see the manifests available in the `vmware_host_logbundle` module.

##### ISSUE TYPE

* New Module Pull Request

##### COMPONENT NAME

vmware_host_logbundle_info

##### ADDITIONAL INFORMATION

tested with vCenter6.7/ESXi6.7, vCenter7.0/ESXi7.0
