### PR TITLE
VMware: Fix errors caused by vSphere API legacy versions(vmware_host_capability_facts)

### DIFF
--- a/changelogs/fragments/fix-vim-legacy-version-error-vmware_host_capability_facts.yml
+++ b/changelogs/fragments/fix-vim-legacy-version-error-vmware_host_capability_facts.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_host_capability_facts - Fixed vSphere API legacy version errors occur in pyvmomi 7.0 and later

--- a/plugins/modules/vmware_host_capability_facts.py
+++ b/plugins/modules/vmware_host_capability_facts.py
@@ -136,7 +136,6 @@ class CapabilityFactsManager(PyVmomi):
                 recordReplaySupported=hc.recordReplaySupported,
                 ftSupported=hc.ftSupported,
                 replayUnsupportedReason=hc.replayUnsupportedReason,
-                checkpointFtSupported=hc.checkpointFtSupported,
                 smpFtSupported=hc.smpFtSupported,
                 maxVcpusPerFtVm=hc.maxVcpusPerFtVm,
                 loginBySSLThumbprintSupported=hc.loginBySSLThumbprintSupported,
@@ -196,10 +195,16 @@ class CapabilityFactsManager(PyVmomi):
                 supportedVmfsMajorVersion=[version for version in hc.supportedVmfsMajorVersion],
                 vmDirectPathGen2UnsupportedReason=[reason for reason in hc.vmDirectPathGen2UnsupportedReason],
                 ftCompatibilityIssues=[issue for issue in hc.ftCompatibilityIssues],
-                checkpointFtCompatibilityIssues=[issue for issue in hc.checkpointFtCompatibilityIssues],
                 smpFtCompatibilityIssues=[issue for issue in hc.smpFtCompatibilityIssues],
                 replayCompatibilityIssues=[issue for issue in hc.replayCompatibilityIssues],
             )
+
+            if hasattr(hc, 'checkpointFtSupported'):
+                hosts_capability_facts[host.name]['checkpointFtSupported'] = hc.checkpointFtSupported
+
+            if hasattr(hc, 'checkpointFtCompatibilityIssues'):
+                hosts_capability_facts[host.name]['checkpointFtCompatibilityIssues'] = [issue for issue in hc.checkpointFtCompatibilityIssues],
+
         return hosts_capability_facts
 
 

--- a/plugins/modules/vmware_host_capability_facts.py
+++ b/plugins/modules/vmware_host_capability_facts.py
@@ -199,11 +199,14 @@ class CapabilityFactsManager(PyVmomi):
                 replayCompatibilityIssues=[issue for issue in hc.replayCompatibilityIssues],
             )
 
-            if hasattr(hc, 'checkpointFtSupported'):
-                hosts_capability_facts[host.name]['checkpointFtSupported'] = hc.checkpointFtSupported
-
-            if hasattr(hc, 'checkpointFtCompatibilityIssues'):
-                hosts_capability_facts[host.name]['checkpointFtCompatibilityIssues'] = [issue for issue in hc.checkpointFtCompatibilityIssues],
+            # The `checkpointFtSupported` and `checkpointFtCompatibilityIssues` properties have been removed from pyvmomi 7.0.
+            # The parameters can be substituted as follows.
+            #   checkpointFtSupported => smpFtSupported
+            #   checkpointFtSupported => smpFtCompatibilityIssues.
+            # So add `checkpointFtSupported` and `checkpointFtCompatibilityIssues` keys for compatibility with previous versions.
+            # https://github.com/ansible-collections/vmware/pull/118
+            hosts_capability_facts[host.name]['checkpointFtSupported'] = hosts_capability_facts[host.name]['smpFtSupported']
+            hosts_capability_facts[host.name]['checkpointFtCompatibilityIssues'] = hosts_capability_facts[host.name]['smpFtCompatibilityIssues']
 
         return hosts_capability_facts
 

--- a/tests/integration/targets/vmware_host_capability_facts/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_capability_facts/tasks/main.yml
@@ -23,6 +23,8 @@
       that:
         - not (capability_0001_results is changed)
         - capability_0001_results.hosts_capability_facts is defined
+        - capability_0001_results.hosts_capability_facts[esxi1].checkpointFtSupported is defined
+        - capability_0001_results.hosts_capability_facts[esxi1].checkpointFtCompatibilityIssues is defined
 
   - name: Gather capability facts for ESXi host
     vmware_host_capability_facts:
@@ -36,3 +38,5 @@
       that:
         - not (capability_0002_results is changed)
         - capability_0002_results.hosts_capability_facts is defined
+        - capability_0002_results.hosts_capability_facts[esxi1].checkpointFtSupported is defined
+        - capability_0002_results.hosts_capability_facts[esxi1].checkpointFtCompatibilityIssues is defined


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/vmware/pull/122

##### SUMMARY

When I run this module with the latest pyvmomi, I get the following error.

```
The full traceback is:
Traceback (most recent call last):
  File "/root/.ansible/tmp/ansible-tmp-1586962923.432382-22973-240608536804152/AnsiballZ_vmware_host_capability_info.py", line 116, in <module>
    _ansiballz_main()
  File "/root/.ansible/tmp/ansible-tmp-1586962923.432382-22973-240608536804152/AnsiballZ_vmware_host_capability_info.py", line 108, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/root/.ansible/tmp/ansible-tmp-1586962923.432382-22973-240608536804152/AnsiballZ_vmware_host_capability_info.py", line 54, in invoke_module
    runpy.run_module(mod_name='ansible_collections.community.vmware.plugins.modules.vmware_host_capability_info', init_globals=None, run_name='__main__', alter_sys=True)
  File "/usr/lib64/python3.6/runpy.py", line 205, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File "/usr/lib64/python3.6/runpy.py", line 96, in _run_module_code
    mod_name, mod_spec, pkg_name, script_name)
  File "/usr/lib64/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/tmp/ansible_vmware_host_capability_info_payload_tu3ahy1p/ansible_vmware_host_capability_info_payload.zip/ansible_collections/community/vmware/plugins/modules/vmware_host_capability_info.py", line 223, in <module>
  File "/tmp/ansible_vmware_host_capability_info_payload_tu3ahy1p/ansible_vmware_host_capability_info_payload.zip/ansible_collections/community/vmware/plugins/modules/vmware_host_capability_info.py", line 219, in main
  File "/tmp/ansible_vmware_host_capability_info_payload_tu3ahy1p/ansible_vmware_host_capability_info_payload.zip/ansible_collections/community/vmware/plugins/modules/vmware_host_capability_info.py", line 135, in gather_host_capability_info
AttributeError: 'vim.host.Capability' object has no attribute 'checkpointFtSupported'
fatal: [testhost]: FAILED! => {
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"/root/.ansible/tmp/ansible-tmp-1586962923.432382-22973-240608536804152/AnsiballZ_vmware_host_capability_info.py\", line 116, in <module>\n    _ansiballz_main()\n  File \"/root/.ansible/tmp/ansible-tmp-1586962923.432382-22973-240608536804152/AnsiballZ_vmware_host_capability_info.py\", line 108, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/root/.ansible/tmp/ansible-tmp-1586962923.432382-22973-240608536804152/AnsiballZ_vmware_host_capability_info.py\", line 54, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.community.vmware.plugins.modules.vmware_host_capability_info', init_globals=None, run_name='__main__', alter_sys=True)\n  File \"/usr/lib64/python3.6/runpy.py\", line 205, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib64/python3.6/runpy.py\", line 96, in _run_module_code\n    mod_name, mod_spec, pkg_name, script_name)\n  File \"/usr/lib64/python3.6/runpy.py\", line 85, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_vmware_host_capability_info_payload_tu3ahy1p/ansible_vmware_host_capability_info_payload.zip/ansible_collections/community/vmware/plugins/modules/vmware_host_capability_info.py\", line 223, in <module>\n  File \"/tmp/ansible_vmware_host_capability_info_payload_tu3ahy1p/ansible_vmware_host_capability_info_payload.zip/ansible_collections/community/vmware/plugins/modules/vmware_host_capability_info.py\", line 219, in main\n  File \"/tmp/ansible_vmware_host_capability_info_payload_tu3ahy1p/ansible_vmware_host_capability_info_payload.zip/ansible_collections/community/vmware/plugins/modules/vmware_host_capability_info.py\", line 135, in gather_host_capability_info\nAttributeError: 'vim.host.Capability' object has no attribute 'checkpointFtSupported'\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}
```

The reason for this error is that the `checkpointFtSupported` and `checkpointFtCompatibilityIssues` properties have been removed from pyvmomi 7.0

see `pyVmomi/ServerObjects.py` below link

https://github.com/vmware/pyvmomi/commit/24092db0bb397eea0316c3bd81f7f94794bdc8b4#diff-2d5bf7bb91bd2937b1a9aa8354a5b792L1321

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

vmware_host_capability_facts

##### ADDITIONAL INFORMATION

Related same PR: https://github.com/ansible-collections/vmware/pull/118