### PR TITLE
req: pyvmomi < 7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pyvmomi
+pyvmomi < 7.0.0
 git+https://github.com/vmware/vsphere-automation-sdk-python.git ; python_version >= '2.7'  # Python 2.6 is not supported


### PR DESCRIPTION
Ensure we don't use pyvmomi 7.0 yet since it breaks `vmware_host_capability_facts` and `vmware_host_capability_info`.

See: https://github.com/ansible-collections/vmware/issues/116
See: https://github.com/vmware/pyvmomi/issues/893