### PR TITLE
Add feature migrate from Distributed Switch to Standard Switch

### DIFF
--- a/changelogs/fragments/124-vmware-migrate-vmk-to-std-switch.yaml
+++ b/changelogs/fragments/124-vmware-migrate-vmk-to-std-switch.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-- to also allow migration from a VMware vSphere Distrubuted Switch to a ESXi Standard Switch
+- vmware_migrate_vmk - allow migration from a VMware vSphere Distrubuted Switch to a ESXi Standard Switch

--- a/changelogs/fragments/124-vmware-migrate-vmk-to-std-switch.yaml
+++ b/changelogs/fragments/124-vmware-migrate-vmk-to-std-switch.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- to also allow migration from a VMware vSphere Distrubuted Switch to a ESXi Standard Switch

--- a/plugins/modules/vmware_migrate_vmk.py
+++ b/plugins/modules/vmware_migrate_vmk.py
@@ -190,8 +190,10 @@ class VMwareMigrateVmk(object):
 
         for vnic in self.host_system.configManager.networkSystem.networkInfo.vnic:
             if vnic.device == self.device:
-                # self.vnic = vnic
                 if vnic.spec.distributedVirtualPort is None:
+                    std_vswitches = [vswitch.name for vswitch in self.host_system.configManager.networkSystem.networkInfo.vswitch]
+                    if self.current_switch_name not in std_vswitches:
+                        return "migrated"
                     if vnic.portgroup == self.current_portgroup_name:
                         return "migrate_vss_vds"
                 else:

--- a/plugins/modules/vmware_migrate_vmk.py
+++ b/plugins/modules/vmware_migrate_vmk.py
@@ -21,7 +21,7 @@ author:
 - Joseph Callen (@jcpowermac)
 - Russell Teague (@mtnbikenc)
 notes:
-    - Tested on vSphere 5.5
+    - Tested on vSphere 6.7
 requirements:
     - "python >= 2.6"
     - PyVmomi
@@ -120,8 +120,33 @@ class VMwareMigrateVmk(object):
     def state_exit_unchanged(self):
         self.module.exit_json(changed=False)
 
+    def create_host_vnic_config_vds_vss(self):
+        host_vnic_config = vim.host.VirtualNic.Config()
+        host_vnic_config.spec = vim.host.VirtualNic.Specification()
+        host_vnic_config.changeOperation = "edit"
+        host_vnic_config.device = self.device
+        host_vnic_config.spec.portgroup = self.migrate_portgroup_name
+        return host_vnic_config
+
+    def create_port_group_config_vds_vss(self):
+        port_group_config = vim.host.PortGroup.Config()
+        port_group_config.spec = vim.host.PortGroup.Specification()
+        port_group_config.changeOperation = "add"
+        port_group_config.spec.name = self.migrate_portgroup_name
+        port_group_config.spec.vlanId = 0
+        port_group_config.spec.vswitchName = self.migrate_switch_name
+        port_group_config.spec.policy = vim.host.NetworkPolicy()
+        return port_group_config
+
     def state_migrate_vds_vss(self):
-        self.module.exit_json(changed=False, msg="Currently Not Implemented")
+        host_network_system = self.host_system.configManager.networkSystem
+        config = vim.host.NetworkConfig()
+        config.portgroup = [self.create_port_group_config_vds_vss()]
+        host_network_system.UpdateNetworkConfig(config, "modify")
+        config = vim.host.NetworkConfig()
+        config.vnic = [self.create_host_vnic_config_vds_vss()]
+        host_network_system.UpdateNetworkConfig(config, "modify")
+        self.module.exit_json(changed=True)
 
     def create_host_vnic_config(self, dv_switch_uuid, portgroup_key):
         host_vnic_config = vim.host.VirtualNic.Config()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Edited the funtion state_migrate_vds_vss which returns the message "Currently Not Implemented" to allow migration from a VMware vSphere Distrubuted Switch to a ESXi Standard Switch
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->



##### COMPONENT NAME
vmware_migrate_vmk

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
- Create a portgroup on the named destination standard vSwitch "migrate_switch_name"
- Update the ESXi host network settings
- Create a VirtualNic (vmk) in edit mode on the portgroup (above) to allow a migration to happen
- Update the ESXi host network settings - causing the migration to start
