### PR TITLE
temporarily disable vmware_guest_network

### DIFF
--- a/tests/integration/targets/vmware_guest_network/aliases
+++ b/tests/integration/targets/vmware_guest_network/aliases
@@ -2,4 +2,4 @@ cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi_with_nested
-zuul/vmware/govcsim
+disabled


### PR DESCRIPTION
When the test run on a LimeStone Cloud node, we've got a high rate
of failure. I need to investigate the problem.
Also remove the test from `zuul/vmware/govcsim`