### PR TITLE
Revert "req: pyvmomi < 7.0 (#122)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pyvmomi < 7.0.0
+pyvmomi
 git+https://github.com/vmware/vsphere-automation-sdk-python.git ; python_version >= '2.7'  # Python 2.6 is not supported


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/vmware/pull/194

This reverts commit 5ca75cffaf8cf53fb3f99ea412bb7bfd1048360b.

Thanks to the two following changes, we can now use pyvmomi 7.0:

- 813f6c126ffd64207c5b7c8b4f8aa32f13e492f4
- 531b099bbbe57f1fbdb1868868be65e9304bb74f