### PR TITLE
Revert "Temporarily disable Tag and Category tests"

### DIFF
--- a/tests/integration/targets/prepare_vmware_tests/tasks/init_real_lab.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/init_real_lab.yml
@@ -19,11 +19,10 @@
       when: setup_dvswitch is defined
     - include_tasks: setup_resource_pool.yml
       when: setup_resource_pool is defined
-    # Temporarily disabled
-    #- include_tasks: setup_category.yml
-    #  when: setup_category is defined
-    #- include_tasks: setup_tag.yml
-    #  when: setup_tag is defined
+    - include_tasks: setup_category.yml
+      when: setup_category is defined
+    - include_tasks: setup_tag.yml
+      when: setup_tag is defined
     - include_tasks: setup_content_library.yml
       when: setup_content_library is defined
     - include_tasks: setup_dvs_portgroup.yml

--- a/tests/integration/targets/prepare_vmware_tests/tasks/setup_category.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/setup_category.yml
@@ -1,5 +1,9 @@
 - name: Create a category for cluster
   vmware_category:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
     category_name: '{{ cluster_category }}'
     category_description: '{{ cluster_category }} description'
     state: present

--- a/tests/integration/targets/vmware_category/aliases
+++ b/tests/integration/targets/vmware_category/aliases
@@ -2,5 +2,3 @@ shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only
-# Temporarily disabled
-disabled

--- a/tests/integration/targets/vmware_cluster_facts/tasks/main.yml
+++ b/tests/integration/targets/vmware_cluster_facts/tasks/main.yml
@@ -62,20 +62,19 @@
       name: prepare_vmware_tests
     vars:
       setup_category: true
-      # Temporarily disabled
-      # setup_tag: true
+      setup_tag: true
 
-  # - name: Apply tag to cluster
-  #   vmware_tag_manager:
-  #     hostname: "{{ vcenter_hostname }}"
-  #     username: "{{ vcenter_username }}"
-  #     password: "{{ vcenter_password }}"
-  #     validate_certs: no
-  #     tag_names:
-  #       - '{{ cluster_category }}:{{ cluster_tag }}'
-  #     state: present
-  #     object_name: '{{ ccr1 }}'
-  #     object_type: ClusterComputeResource
+  - name: Apply tag to cluster
+    vmware_tag_manager:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      validate_certs: no
+      tag_names:
+        - '{{ cluster_category }}:{{ cluster_tag }}'
+      state: present
+      object_name: '{{ ccr1 }}'
+      object_type: ClusterComputeResource
 
   - name: Get facts about cluster
     vmware_cluster_facts:
@@ -90,4 +89,4 @@
   - assert:
       that:
         - cluster_info is defined
-        #- cluster_info.clusters[ccr1].tags is defined
+        - cluster_info.clusters[ccr1].tags is defined

--- a/tests/integration/targets/vmware_cluster_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_cluster_info/tasks/main.yml
@@ -61,20 +61,19 @@
       name: prepare_vmware_tests
     vars:
       setup_category: true
-      # Temporarily disabled
-      # setup_tag: true
+      setup_tag: true
 
-  # - name: Apply tag to cluster
-  #   vmware_tag_manager:
-  #     hostname: "{{ vcenter_hostname }}"
-  #     username: "{{ vcenter_username }}"
-  #     password: "{{ vcenter_password }}"
-  #     validate_certs: no
-  #     tag_names:
-  #       - '{{ cluster_category }}:{{ cluster_tag }}'
-  #     state: present
-  #     object_name: '{{ ccr1 }}'
-  #     object_type: ClusterComputeResource
+  - name: Apply tag to cluster
+    vmware_tag_manager:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      validate_certs: no
+      tag_names:
+        - '{{ cluster_category }}:{{ cluster_tag }}'
+      state: present
+      object_name: '{{ ccr1 }}'
+      object_type: ClusterComputeResource
 
   - name: Get info about cluster
     vmware_cluster_info:
@@ -89,4 +88,4 @@
   - assert:
       that:
         - cluster_info is defined
-        #- cluster_info.clusters[ccr1].tags is defined
+        - cluster_info.clusters[ccr1].tags is defined

--- a/tests/integration/targets/vmware_tag/aliases
+++ b/tests/integration/targets/vmware_tag/aliases
@@ -1,5 +1,3 @@
 cloud/vcenter
 unsupported
 zuul/vmware/vcenter_only
-# Temporarily disabled
-disabled

--- a/tests/integration/targets/vmware_tag_info/aliases
+++ b/tests/integration/targets/vmware_tag_info/aliases
@@ -1,5 +1,3 @@
 cloud/vcenter
 unsupported
 zuul/vmware/vcenter_only
-# Temporarily disabled
-disabled

--- a/tests/integration/targets/vmware_tag_manager/aliases
+++ b/tests/integration/targets/vmware_tag_manager/aliases
@@ -2,5 +2,3 @@ cloud/vcenter
 unsupported
 zuul/vmware/vcenter_only
 zuul/vmware/govcsim
-# Temporarily disabled
-disabled


### PR DESCRIPTION
This reverts commit ba89d6adb2b536c61fa03fef150f0c186feaa6c5.

We should not need this anymore.