### PR TITLE
add storage_provisioning type into vmware_content_deploy_ovf_template.

### DIFF
--- a/changelogs/fragments/vmware_content_deploy_ovf_template_add_storage_provision_type.yml
+++ b/changelogs/fragments/vmware_content_deploy_ovf_template_add_storage_provision_type.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - add storage_provisioning type into vmware_content_deploy_ovf_template.

--- a/plugins/modules/vmware_content_deploy_ovf_template.py
+++ b/plugins/modules/vmware_content_deploy_ovf_template.py
@@ -93,7 +93,7 @@ EXAMPLES = r'''
     validate_certs: False
   delegate_to: localhost
 
-- name: Deploy Virtual Machine from OVF template in content library with thin storage
+- name: Deploy Virtual Machine from OVF template in content library with eagerZeroedThick storage
   vmware_content_deploy_ovf_template:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
@@ -105,7 +105,7 @@ EXAMPLES = r'''
     name: Sample_VM
     resource_pool: test_rp
     validate_certs: False
-    storage_provisioning: thin
+    storage_provisioning: eagerZeroedThick
   delegate_to: localhost
 '''
 


### PR DESCRIPTION
#### SUMMARY
It allows to customize storage provisioning type. Without that options server will decide to use thin, thick oreagerZeroedThick type of storage provisioning

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_content_deploy_ovf_template.py

##### ADDITIONAL INFORMATION
http://vmware.github.io/vsphere-automation-sdk-rest/6.5/operations/com/vmware/vcenter/ovf/library_item.deploy-operation.html
http://vmware.github.io/vsphere-automation-sdk-rest/6.5/structures/com/vmware/vcenter/ovf/libraryitem/svc.resource_pool_deployment_spec-structure.html