### PR TITLE
Add support for filters in inventory plugin

### DIFF
--- a/changelogs/fragments/vmware_vm_inventory_filter.yml
+++ b/changelogs/fragments/vmware_vm_inventory_filter.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- VMware guest inventory plugin support for filters.

--- a/tests/integration/targets/inventory_vmware_vm_inventory/playbook/test_options.yml
+++ b/tests/integration/targets/inventory_vmware_vm_inventory/playbook/test_options.yml
@@ -151,6 +151,27 @@
         that:
           - "'poweredOff' in test_host.value.group_names"
 
+
+    - name: Inventory filters options
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_vm_inventory
+          strict: False
+          with_nested_properties: True
+          properties:
+            - config.name
+            - runtime.powerState
+          filters:
+            - runtime.powerState == "poweredOff"
+          hostnames:
+            - config.name
+
+    - name: Test filters options
+      assert:
+        that:
+          - "'DC0_H0_VM0' in test_host.value.groups.all"
+
     - name: Inventory 'with_tag' option
       include_tasks: build_inventory.yml
       vars:


### PR DESCRIPTION
##### SUMMARY

This PR is based upon the work of dacrystal

This PR adds functionality of filters. This will allow user to
filter down the hosts based upon jinja templating.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/vmware_vm_inventory_filter.yml
plugins/inventory/vmware_vm_inventory.py
tests/integration/targets/inventory_vmware_vm_inventory/playbook/test_options.yml
