### PR TITLE
Correct the set fact to fit the return structure

### DIFF
--- a/changelogs/fragments/141_Correct_doc_of_vmware_local_role_info
+++ b/changelogs/fragments/141_Correct_doc_of_vmware_local_role_info
@@ -1,0 +1,2 @@
+minor_changes:
+- Correct example from doc of `vmware_local_role_info.py` to match the change of returned structure.

--- a/plugins/modules/vmware_local_role_info.py
+++ b/plugins/modules/vmware_local_role_info.py
@@ -45,7 +45,7 @@ EXAMPLES = '''
   delegate_to: localhost
 - name: Get Admin privileges
   set_fact:
-    admin_priv: "{{ fact_details.local_role_info['Admin']['privileges'] }}"
+    admin_priv: "{{ fact_details.local_role_info | selectattr('role_name', 'equalto', 'Admin') | map(attribute='privileges') | first  }}"
 - debug:
     msg: "{{ admin_priv }}"
 '''
@@ -54,7 +54,7 @@ RETURN = r'''
 local_role_info:
     description: Info about role present on ESXi host
     returned: always
-    type: dict
+    type: list of dict
     sample: [
         {
             "privileges": [

--- a/plugins/modules/vmware_local_role_info.py
+++ b/plugins/modules/vmware_local_role_info.py
@@ -52,7 +52,7 @@ EXAMPLES = '''
 
 RETURN = r'''
 local_role_info:
-    description: Info about role present on ESXi host
+    description: A list of dict about role information present on ESXi host
     returned: always
     type: list of dict
     sample: [


### PR DESCRIPTION
It seems there was a structure change of what is returned by the module. It's now a list of dict and what was the key become the value of `role_name`. I adapted the example with jinja2 filter to access the privileges list of 'Admin'.

I also adapted the type. PS: I'm not sure about that change. Maybe it should be only `type: list`…

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
