### PR TITLE
Cast as integer in vmware_dvs_portgroup_find

### DIFF
--- a/changelogs/fragments/145-vmware_dvs_portgroup_find-integer-cast.yaml
+++ b/changelogs/fragments/145-vmware_dvs_portgroup_find-integer-cast.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- vmware_dvs_portgroup_find - Cast variable to integer for comparison.

--- a/plugins/modules/vmware_dvs_portgroup_find.py
+++ b/plugins/modules/vmware_dvs_portgroup_find.py
@@ -141,7 +141,7 @@ class DVSPortgroupFindManager(PyVmomi):
         for ln in vlanlst:
             if '-' in ln:
                 arr = ln.split('-')
-                if arr[0] < self.vlan and self.vlan < arr[1]:
+                if int(arr[0]) < self.vlan and self.vlan < int(arr[1]):
                     res = True
             elif ln == str(self.vlan):
                 res = True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Attempts to fix #143. Casts `arr` as an integer in comparison.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`vmware_dvs_portgroup_find`
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Solution suggested in #143.
Fixes: #141 