### PR TITLE
Filter VM based upon resources in vmware_vm_inventory

### DIFF
--- a/changelogs/fragments/vmware_vm_inventory_resources.yml
+++ b/changelogs/fragments/vmware_vm_inventory_resources.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Added server side filtering using resources in vmware_vm_inventory plugin.

--- a/tests/integration/targets/inventory_vmware_vm_inventory/playbook/test_options.yml
+++ b/tests/integration/targets/inventory_vmware_vm_inventory/playbook/test_options.yml
@@ -225,3 +225,101 @@
         that:
           - "'tags' in test_host.value"
       when: not (vcsim is defined)
+
+    - name: Inventory 'resources' option
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_vm_inventory
+          strict: False
+          with_nested_properties: False
+          hostnames:
+            - config.name
+          properties:
+            - config.name
+          resources:
+            - datacenter:
+                - DC0
+              resources:
+                - compute_resource:
+                    - DC0_C0
+
+    - name: Test 'resources' options
+      assert:
+        that:
+          - "'DC0_C0_RP0_VM0' in hostvars"
+
+    - name: Inventory 'resources' option
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_vm_inventory
+          strict: False
+          with_nested_properties: False
+          hostnames:
+            - config.name
+          properties:
+            - config.name
+          resources:
+            - datacenter:
+                - DC0
+              resources:
+                - compute_resource:
+                    - DC0_C0
+                    - DC0_C0_NOT_EXIST
+
+    - name: Test 'resources' options with 'DC0_C0' and 'DC0_C0_NOT_EXIST'
+      assert:
+        that:
+          - "'DC0_C0_RP0_VM0' in hostvars"
+
+    - name: Inventory 'resources' option
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_vm_inventory
+          strict: False
+          with_nested_properties: False
+          hostnames:
+            - config.name
+          properties:
+            - config.name
+          resources:
+            - datacenter:
+                - DC0
+              resources:
+                - compute_resource:
+                    - DC0_C0
+            - datacenter:
+                - DC0
+              resources:
+                - compute_resource:
+                    - DC0_C0_NOT_EXIST
+
+    - name: Test 'resources' options with 'DC0_C0' and 'DC0_C0_NOT_EXIST' using two 'datacenter'
+      assert:
+        that:
+          - "'DC0_C0_RP0_VM0' in hostvars"
+
+    - name: Inventory 'resources' option
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_vm_inventory
+          strict: False
+          with_nested_properties: False
+          hostnames:
+            - config.name
+          properties:
+            - config.name
+          resources:
+            - datacenter:
+                - DC0
+              resources:
+                - compute_resource:
+                    - DC0_C0_NOT_EXIST
+
+    - name: Test 'resources' options with 'DC0_C0_NOT_EXIST'
+      assert:
+        that:
+          - hostvars | length == 0


### PR DESCRIPTION
##### SUMMARY

This PR is based upon work done by dacrystal

This PR provides server side filtering VMs based upon various VMware
resources like Datacenter, Cluster and Folder etc.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/vmware_vm_inventory_resources.yml
plugins/inventory/vmware_vm_inventory.py
tests/integration/targets/inventory_vmware_vm_inventory/playbook/test_options.yml
