### PR TITLE
Revert "temporarily disable vmware_guest_network (#131)"

### DIFF
--- a/tests/integration/targets/vmware_guest_network/aliases
+++ b/tests/integration/targets/vmware_guest_network/aliases
@@ -2,4 +2,4 @@ cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi_with_nested
-disabled
+zuul/vmware/govcsim


### PR DESCRIPTION
This reverts commit 060cc998d7f532a5d39081b316f855d570be3304.

This should better now.
See: https://github.com/ansible-network/windmill-config/commit/6753f5fab7c0a2e3859bf43231f10fcfd6d8f77c
