### PR TITLE
Remove duplicate check

### DIFF
--- a/changelogs/fragments/145-vmware_dvs_portgroup_find-integer-cast.yaml
+++ b/changelogs/fragments/145-vmware_dvs_portgroup_find-integer-cast.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- vmware_dvs_portgroup_find - Cast variable to integer for comparison.

--- a/plugins/modules/vmware_dvs_portgroup_find.py
+++ b/plugins/modules/vmware_dvs_portgroup_find.py
@@ -141,7 +141,7 @@ class DVSPortgroupFindManager(PyVmomi):
         for ln in vlanlst:
             if '-' in ln:
                 arr = ln.split('-')
-                if arr[0] < self.vlan and self.vlan < arr[1]:
+                if int(arr[0]) < self.vlan and self.vlan < int(arr[1]):
                     res = True
             elif ln == str(self.vlan):
                 res = True

--- a/plugins/modules/vmware_vmkernel.py
+++ b/plugins/modules/vmware_vmkernel.py
@@ -1024,11 +1024,7 @@ class PyVmomiHelper(PyVmomi):
             net_stack_instance = 'default'
         elif tcpip_stack == 'vSphereProvisioning':
             net_stack_instance = 'provisioning'
-        # vmotion and vxlan stay the same
-        elif tcpip_stack == 'vmotion':
-            net_stack_instance = 'vmotion'
-        elif tcpip_stack == 'vxlan':
-            net_stack_instance = 'vxlan'
+
         return net_stack_instance
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`vmware_vmkernel` had duplicate checks in the `get_api_net_stack_instance()` method. This PR removes them.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`vmware_vmkernel`