### PR TITLE
VMware: add hardware version 17 support in vmware_guest module

### DIFF
--- a/changelogs/fragments/153-vmware_guest.yml
+++ b/changelogs/fragments/153-vmware_guest.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_guest - add support hardware version 17 for vSphere 7.0 

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -1327,12 +1327,12 @@ class PyVmomiHelper(PyVmomi):
                     except ValueError:
                         hw_version_check_failed = True
 
-                    if temp_version not in range(3, 16):
+                    if temp_version not in range(3, 18):
                         hw_version_check_failed = True
 
                     if hw_version_check_failed:
                         self.module.fail_json(msg="Failed to set hardware.version '%s' value as valid"
-                                              " values range from 3 (ESX 2.x) to 15 (ESXi 6.7U2 and greater)." % temp_version)
+                                              " values range from 3 (ESX 2.x) to 17 (ESXi 7.0)." % temp_version)
                     # Hardware version is denoted as "vmx-10"
                     version = "vmx-%02d" % temp_version
                     self.configspec.version = version


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Since vSphere 7.0 is released and new hardware 17 introduced, add this hardware version support in vmware_guest module for creating VM.
 
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Tested on vSphere 7.0 with hardware version 17, 15 and latest, VM created as expected.
```
