### PR TITLE
VMware: add vm existence check processing to vmware_deploy_ovf module

### DIFF
--- a/changelogs/fragments/166-vmware_deploy_ovf.yml
+++ b/changelogs/fragments/166-vmware_deploy_ovf.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_deploy_ovf - Fixed ova deploy error occur if vm exists

--- a/plugins/modules/vmware_deploy_ovf.py
+++ b/plugins/modules/vmware_deploy_ovf.py
@@ -189,7 +189,8 @@ from ansible_collections.community.vmware.plugins.module_utils.vmware import (
     gather_vm_facts,
     vmware_argument_spec,
     wait_for_task,
-    wait_for_vm_ip)
+    wait_for_vm_ip,
+    set_vm_power_state)
 try:
     from ansible_collections.community.vmware.plugins.module_utils.vmware import vim
     from pyVmomi import vmodl
@@ -479,6 +480,13 @@ class VMwareDeployOvf(PyVmomi):
 
         return urlunparse(url_parts.as_list())
 
+    def vm_existence_check(self):
+        vm_obj = self.get_vm()
+        if vm_obj:
+            self.entity = vm_obj
+            facts = self.deploy()
+            self.module.exit_json(**facts)
+
     def upload(self):
         if self.params['ovf'] is None:
             self.module.fail_json(msg="OVF path is required for upload operation.")
@@ -597,18 +605,12 @@ class VMwareDeployOvf(PyVmomi):
     def deploy(self):
         facts = {}
 
-        if self.params['inject_ovf_env']:
-            self.inject_ovf_env()
-
         if self.params['power_on']:
-            task = self.entity.PowerOn()
-            if self.params['wait']:
-                wait_for_task(task)
-                if self.params['wait_for_ip_address']:
-                    _facts = wait_for_vm_ip(self.content, self.entity)
-                    if not _facts:
-                        self.module.fail_json(msg='Waiting for IP address timed out')
-                    facts.update(_facts)
+            facts = set_vm_power_state(self.content, self.entity, 'poweredon', force=False)
+            if self.params['wait_for_ip_address']:
+                _facts = wait_for_vm_ip(self.content, self.entity)
+                if not _facts:
+                    self.module.fail_json(msg='Waiting for IP address timed out')
 
         if not facts:
             facts.update(gather_vm_facts(self.content, self.entity))
@@ -697,11 +699,16 @@ def main():
     )
 
     deploy_ovf = VMwareDeployOvf(module)
+    deploy_ovf.vm_existence_check()
     deploy_ovf.upload()
     deploy_ovf.complete()
-    facts = deploy_ovf.deploy()
 
-    module.exit_json(instance=facts, changed=True)
+    if module.params['inject_ovf_env']:
+        deploy_ovf.inject_ovf_env()
+
+    facts = deploy_ovf.deploy()
+    facts.update(changed=True)
+    module.exit_json(**facts)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY

The vmware_deploy_ovf module does not check for the existence of a VM, so an error occurs if the VM already exists.
This PR adds vm existence check processing to the vmware_deploy_ovf module.

fixes: https://github.com/ansible-collections/vmware/issues/152

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

vmware_deploy_ovf

##### ADDITIONAL INFORMATION

tested on vCenter/ESXi 6.7
