### PR TITLE
specify the name of the content library from where the template needs…

### DIFF
--- a/changelogs/fragments/188-vmware_content_deploy_template-specify_content_library_name.yml
+++ b/changelogs/fragments/188-vmware_content_deploy_template-specify_content_library_name.yml
@@ -1,3 +1,3 @@
 minor_changes:
-  - vmware_content_deploy_template - added field content_library to search template inside the specified content library.
+  - vmware_content_deploy_template - added new field "content_library" to search template inside the specified content library.
   - vmware_rest_client - Added a new definition get_library_item_from_content_library_name.

--- a/changelogs/fragments/188-vmware_content_deploy_template-specify_content_library_name.yml
+++ b/changelogs/fragments/188-vmware_content_deploy_template-specify_content_library_name.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - vmware_content_deploy_template - added field content_library to search template inside the specified content library.
+  - vmware_rest_client - Added a new definition get_library_item_from_content_library_name.

--- a/plugins/module_utils/vmware_rest_client.py
+++ b/plugins/module_utils/vmware_rest_client.py
@@ -294,6 +294,27 @@ class VmwareRestClient(object):
         item_id = item_ids[0] if item_ids else None
         return item_id
 
+    def get_library_item_from_content_library_name(self, name, content_library_name):
+        """
+        Returns the identifier of the library item with the given name in the specified
+        content library.
+        Args:
+            name (str): The name of item to look for
+            content_library_name (str): The name of the content library to search in
+        Returns:
+            str: The item ID or None if the item is not found
+        """
+        cl_find_spec = self.api_client.content.Library.FindSpec(name=content_library_name)
+        cl_item_ids = self.api_client.content.Library.find(cl_find_spec)
+        cl_item_id = cl_item_ids[0] if cl_item_ids else None
+        if cl_item_id:
+            find_spec = Item.FindSpec(name=name, library_id=cl_item_id)
+            item_ids = self.api_client.content.library.Item.find(find_spec)
+            item_id = item_ids[0] if item_ids else None
+            return item_id
+        else:
+            return None
+
     def get_datacenter_by_name(self, datacenter_name):
         """
         Returns the identifier of a datacenter

--- a/plugins/modules/vmware_content_deploy_template.py
+++ b/plugins/modules/vmware_content_deploy_template.py
@@ -38,6 +38,12 @@ options:
       type: str
       required: True
       aliases: ['template_src']
+    content_library:
+      description:
+      - The name of the content library from where the template resides.
+      type: str
+      required: False
+      aliases: ['content_library_src']
     name:
       description:
       - The name of the VM to be deployed.
@@ -112,6 +118,7 @@ EXAMPLES = r'''
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     template: rhel_test_template
+    content_library: test_content_library
     datastore: Shared_NFS_Volume
     folder: vm
     datacenter: Sample_DC_1
@@ -152,6 +159,7 @@ class VmwareContentDeployTemplate(VmwareRestClient):
         super(VmwareContentDeployTemplate, self).__init__(module)
         self.template_service = self.api_client.vcenter.vm_template.LibraryItems
         self.template_name = self.params.get('template')
+        self.content_library_name = self.params.get('content_library')
         self.vm_name = self.params.get('name')
         self.datacenter = self.params.get('datacenter')
         self.datastore = self.params.get('datastore')
@@ -170,9 +178,15 @@ class VmwareContentDeployTemplate(VmwareRestClient):
         if not self.datastore_id:
             self.module.fail_json(msg="Failed to find the datastore %s" % self.datastore)
         # Find the LibraryItem (Template) by the given LibraryItem name
-        self.library_item_id = self.get_library_item_by_name(self.template_name)
-        if not self.library_item_id:
-            self.module.fail_json(msg="Failed to find the library Item %s" % self.template_name)
+        if self.content_library_name:
+            self.library_item_id = self.get_library_item_from_content_library_name(
+                self.template_name, self.content_library_name)
+            if not self.library_item_id:
+                self.module.fail_json(msg="Failed to find the library Item %s in content library %s" % (self.template_name, self.content_library_name))
+        else:
+            self.library_item_id = self.get_library_item_by_name(self.template_name)
+            if not self.library_item_id:
+                self.module.fail_json(msg="Failed to find the library Item %s" % self.template_name)
         # Find the folder by the given folder name
         self.folder_id = self.get_folder_by_name(self.datacenter, self.folder)
         if not self.folder_id:


### PR DESCRIPTION
… to be picked

##### SUMMARY
Added the functionality to be able to specify the name of the content library from where the template needs to be picked from. The existing functionality will prevail if the field _content_library_
is not specified. 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_content_deploy_template.py 

##### ADDITIONAL INFORMATION
Currently, if we have templates with the same name in multiple content libraries then the first template that matches the template name is returned. Being able to specify the content library name with the template name gives more control for choosing the template.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
###### No change in the output if vm creation successful

###### If the template or the content library specified does not exist
fatal: [localhost -> localhost]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "cluster": null,
            "content_library": "<content_library_name>",
            "datacenter": "<datacenter name>",
            "datastore": "<datastore_name>",
            "folder": "<folder_name>",
            "host": "<host_name>",
            "hostname": "<vcenter_name>",
            "name": "<virtual_machine_name>",
            "password": "<password>",
            "protocol": "https",
            "resource_pool": null,
            "state": "poweredon",
            "template": "<template_name>",
            "username": "<user_name>",
            "validate_certs": false
        }
    },
    "msg": "Failed to find the library Item <template_name> in content library <content_library_name>"
}
```
