### PR TITLE
Fix import error for galaxy.ansible.com

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,6 @@ readme: README.md
 authors:
   - Ansible (https://github.com/ansible)
 description:
-license: GPL-3.0-or-later
 license_file: COPYING
 tags:
   - cloud


### PR DESCRIPTION
Galaxy doesn't seem to support both tags at the same time. So switch to
license_file.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>