### PR TITLE
galaxy: remove license_file key

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,7 +10,6 @@ authors:
   - Ansible (https://github.com/ansible)
 description:
 license: GPL-3.0-or-later
-license_file: COPYING
 tags:
   - cloud
   - vmware


### PR DESCRIPTION
This to address the following problem during the upload on Galaxy:

    The 'license' and 'license_file' keys are mutually exclusive