### PR TITLE
Fix vmware docs

### DIFF
--- a/plugins/modules/vmware_vc_infraprofile_info.py
+++ b/plugins/modules/vmware_vc_infraprofile_info.py
@@ -147,11 +147,11 @@ RETURN = r'''
     import_profile:
         description: A message about import on import_profile spec
         returned: On success with API set as "import"
-    "sample": {
-        "changed": true,
-        "failed": false,
-        "status": "0.0"
-    }
+        "sample": {
+            "changed": true,
+            "failed": false,
+            "status": "0.0"
+        }
 '''
 
 from ansible.module_utils.basic import AnsibleModule


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/vmware/pull/194

##### SUMMARY
The return docs for vmware_vc_infraprofile_info.py were slightly off.  This would cause them to not be displayed on the website and also to fail with the new docs schema that I'm writing.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request


##### COMPONENT NAME
* vmware_vc_infraprofile_info.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
