### PR TITLE
inventory_vmware_vm_inventory test - Remove exit code from trap

### DIFF
--- a/tests/integration/targets/inventory_vmware_vm_inventory/runme.sh
+++ b/tests/integration/targets/inventory_vmware_vm_inventory/runme.sh
@@ -12,7 +12,6 @@ mkdir -p "${INVENTORY_DIR}" 2>/dev/null
 touch "${INVENTORY_DIR}/empty.vmware.yml"
 
 cleanup() {
-    ec=$?
     echo "Cleanup"
     if [ -d "${ANSIBLE_CACHE_PLUGIN_CONNECTION}" ]; then
         echo "Removing ${ANSIBLE_CACHE_PLUGIN_CONNECTION}"
@@ -29,7 +28,6 @@ cleanup() {
     unset INVENTORY_DIR
 
     echo "Done"
-    exit $ec
 }
 
 trap cleanup INT TERM EXIT


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Setting the exit code in a trap overrides the exit code that caused the trap to be called. If any code in the trap fails, the exit call at the end of the trap will never be reached.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`tests/integration/targets/inventory_vmware_vm_inventory/runme.sh`