### PR TITLE
vmware_vm_inventory: Handle binary data in VM properties

### DIFF
--- a/changelogs/fragments/7052_awx_handle_binary.yml
+++ b/changelogs/fragments/7052_awx_handle_binary.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Handle Base64 Binary while JSON serialization in vmware_vm_inventory.

--- a/plugins/inventory/vmware_vm_inventory.py
+++ b/plugins/inventory/vmware_vm_inventory.py
@@ -197,6 +197,7 @@ EXAMPLES = r'''
 
 import ssl
 import atexit
+import base64
 from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.module_utils._text import to_text, to_native
 from ansible.module_utils.common.dict_transformations import dict_merge
@@ -540,6 +541,9 @@ def parse_vim_property(vim_prop):
     elif prop_type in ['bool', 'int', 'NoneType']:
         return vim_prop
 
+    elif prop_type in ['binary']:
+        return to_text(base64.b64encode(vim_prop))
+
     return to_text(vim_prop)
 
 
@@ -680,6 +684,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 properties['tags'] = attached_tags
 
             host_properties = to_nested_dict(properties)
+
             host = self._get_hostname(host_properties, hostnames, strict=strict)
 
             host_filters = self.get_option('filters')

--- a/tests/integration/targets/inventory_vmware_vm_inventory/playbook/test_options.yml
+++ b/tests/integration/targets/inventory_vmware_vm_inventory/playbook/test_options.yml
@@ -225,3 +225,24 @@
         that:
           - "'tags' in test_host.value"
       when: not (vcsim is defined)
+
+    - name: Inventory with binary values (https://github.com/ansible/awx/issues/7052)
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_vm_inventory
+          strict: False
+          with_nested_properties: True
+          properties:
+            - config.vmxConfigChecksum
+            - config.name
+            - summary.runtime.powerState
+          hostnames:
+            - config.name
+
+    - name: Test filters options
+      assert:
+        that:
+          - "'DC0_H0_VM0' in test_host.value.groups.all"
+          - test_host.value.config.name is defined
+          - test_host.value.config.vmxConfigChecksum is defined


### PR DESCRIPTION
##### SUMMARY

VM property like 'vmxConfigChecksum' is Base64Binary. Parsing this
value directly using `to_text` raises `TemplateErrors`.
First encode such values to Base64 and then process further.

Partially fixes https://github.com/ansible/awx/issues/7052

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/7052_awx_handle_binary.yml
plugins/inventory/vmware_vm_inventory.py
tests/integration/targets/inventory_vmware_vm_inventory/playbook/test_options.yml
