### PR TITLE
vmware_category: Fix associable datatypes

### DIFF
--- a/changelogs/fragments/197_vmware_category.yml
+++ b/changelogs/fragments/197_vmware_category.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- vmware_category - fix associable datatypes (https://github.com/ansible-collections/vmware/issues/197).

--- a/plugins/modules/vmware_category.py
+++ b/plugins/modules/vmware_category.py
@@ -78,6 +78,8 @@ options:
       - Host
       - Library item
       - Network
+      - Host Network
+      - Opaque Network
       - Resource Pool
       - vApp
       - Virtual Machine
@@ -198,9 +200,36 @@ class VmwareCategory(VmwareRestClient):
         obj_types_set = []
         if associable_object_types:
             for obj_type in associable_object_types:
-                if obj_type.lower() == 'all objects':
+                lower_obj_type = obj_type.lower()
+                if lower_obj_type == 'all objects':
                     obj_types_set = []
                     break
+                elif lower_obj_type == 'cluster':
+                    obj_types_set.append('ClusterComputeResource')
+                elif lower_obj_type == 'content library':
+                    obj_types_set.append('com.vmware.content.Library')
+                elif lower_obj_type == 'datastore cluster':
+                    obj_types_set.append('StoragePod')
+                elif lower_obj_type == 'distributed port group':
+                    obj_types_set.append('DistributedVirtualPortgroup')
+                elif lower_obj_type == 'distributed switch':
+                    obj_types_set.append('VmwareDistributedVirtualSwitch')
+                elif lower_obj_type == 'host':
+                    obj_types_set.append('HostSystem')
+                elif lower_obj_type == 'library item':
+                    obj_types_set.append('com.vmware.content.library.Item')
+                elif lower_obj_type == 'resource pool':
+                    obj_types_set.append('ResourcePool')
+                elif lower_obj_type == 'vapp':
+                    obj_types_set.append('VirtualApp')
+                elif lower_obj_type == 'virtual machine':
+                    obj_types_set.append('VirtualMachine')
+                elif lower_obj_type == 'network':
+                    obj_types_set.append('Network')
+                elif lower_obj_type == 'host network':
+                    obj_types_set.append('HostNetwork')
+                elif lower_obj_type == 'opaque network':
+                    obj_types_set.append('OpaqueNetwork')
                 else:
                     obj_types_set.append(obj_type)
 
@@ -306,11 +335,11 @@ def main():
         associable_object_types=dict(
             type='list',
             choices=[
-                'All objects', 'Folder', 'Cluster',
-                'Datacenter', 'Datastore', 'Datastore Cluster',
-                'Distributed Port Group', 'Distributed Switch',
-                'Host', 'Content Library', 'Library item', 'Network',
-                'Resource Pool', 'vApp', 'Virtual Machine',
+                'All objects', 'Cluster', 'Content Library', 'Datacenter',
+                'Datastore', 'Datastore Cluster', 'Distributed Port Group', 'Distributed Switch',
+                'Folder', 'Host', 'Library item', 'Network',
+                'Host Network', 'Opaque Network', 'Resource Pool', 'vApp',
+                'Virtual Machine',
             ],
             elements=str,
         ),

--- a/tests/integration/targets/vmware_category/tasks/associable_obj_test.yml
+++ b/tests/integration/targets/vmware_category/tasks/associable_obj_test.yml
@@ -1,0 +1,38 @@
+# Test code for the vmware_category Operations.
+# Copyright: (c) 2020, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Create category named {{ category_name }}
+  vmware_category:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    validate_certs: false
+    category_name: '{{ category_name }}'
+    category_description: '{{ category_name }}'
+    category_cardinality: 'multiple'
+    associable_object_types:
+    - '{{ category_name }}'
+
+- name: Gather category info
+  vmware_category_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+  register: tag_category_results
+
+- name: Get Category datatype for {{ category_name }}
+  set_fact:
+    category_datatype: "{{ cat_obj.category_associable_types }}"
+  loop: "{{ tag_category_results.tag_category_info | selectattr('category_name', 'equalto', category_name) | list }}"
+  loop_control:
+    loop_var: cat_obj
+
+- debug:
+    msg: "{{ category_datatype }}"
+
+- name: Check if we get correct associable datatype for {{ category_name }}
+  assert:
+    that:
+      - "'{{ expected_result }}' in {{ category_datatype }}"

--- a/tests/integration/targets/vmware_category/tasks/associable_obj_types.yml
+++ b/tests/integration/targets/vmware_category/tasks/associable_obj_types.yml
@@ -2,33 +2,47 @@
 # Copyright: (c) 2019, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Create different types of category with associable object types
-  vmware_category:
-    hostname: '{{ vcenter_hostname }}'
-    username: '{{ vcenter_username }}'
-    password: '{{ vcenter_password }}'
-    validate_certs: False
-    category_name: '{{ item }} name'
-    category_description: '{{ item }} description'
-    associable_object_types:
-      - "{{ item }}"
-    state: present
-  with_items:
-    - All objects
-    - Folder
-    - Cluster
-    - Datacenter
-    - Datastore
-    - Datastore Cluster
-    - Distributed Port Group
-    - Distributed Switch
-    - Host
-    - Content Library
-    - Library item
-    - Network
-    - Resource Pool
-    - vApp
-    - Virtual Machine
+- name: Define required data
+  set_facts:
+    cat_data:
+    - name: 'Folder'
+      result: 'Folder'
+    - name: 'Cluster'
+      result: 'ClusterComputeResource'
+    - name: Datacenter
+      result: Datacenter
+    - name: Datastore
+      result: Datastore
+    - name: 'Datastore Cluster'
+      result: 'StoragePod'
+    - name: 'Distributed Port Group'
+      result: 'DistributedVirtualPortgroup'
+    - name: 'Distributed Switch'
+      result: 'VmwareDistributedVirtualSwitch'
+    - name: 'Host'
+      result: 'HostSystem'
+    - name: 'Content Library'
+      result: 'com.vmware.content.Library'
+    - name: 'Library item'
+      result: 'com.vmware.content.library.Item'
+    - name: 'Network'
+      result: 'Network'
+    - name: 'Host Network'
+      result: 'HostNetwork'
+    - name: 'Opaque Network'
+      result: 'OpaqueNetwork'
+    - name: 'Resource Pool'
+      result: 'ResourcePool'
+    - name: 'vApp'
+      result: 'VirtualApp'
+    - name: 'Virtual Machine'
+      result: 'VirtualMachine'
+
+- include_tasks: associable_obj_test.yml
+  vars:
+    category_name: "{{ item.name }}"
+    expected_result: "{{ item.result }}"
+  with_items: "{{ cat_data }}"
 
 - name: Delete different types of category with associable object types
   vmware_category:
@@ -36,24 +50,9 @@
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     validate_certs: False
-    category_name: '{{ item }} name'
+    category_name: '{{ item.name }}'
     state: absent
-  with_items:
-    - All objects
-    - Folder
-    - Cluster
-    - Datacenter
-    - Datastore
-    - Datastore Cluster
-    - Distributed Port Group
-    - Distributed Switch
-    - Host
-    - Content Library
-    - Library item
-    - Network
-    - Resource Pool
-    - vApp
-    - Virtual Machine
+  with_items: "{{ cat_data }}"
 
 - name: Create category with 2 associable object types
   vmware_category:


### PR DESCRIPTION
##### SUMMARY

vCenter uses different resource types for VMware objects.
This fix corrects the resource types.

Fixes: #197

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/197_vmware_category.yml
plugins/modules/vmware_category.py
