### PR TITLE
vmware_host_facts: Handle exception in fact gathering

### DIFF
--- a/changelogs/fragments/183_vmware_host_facts.yml
+++ b/changelogs/fragments/183_vmware_host_facts.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- vmware_host_facts - handle facts when ESXi hostsystem is poweredoff (https://github.com/ansible-collections/vmware/issues/183).


### PR DESCRIPTION
##### SUMMARY

When ESXi hostsystem is poweredoff or in state which module
can not gather facts, it raises exception.

This fix handles exception and returns default values.

Fixes: #183

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/183_vmware_host_facts.yml
plugins/modules/vmware_host_facts.py
