### PR TITLE
Added datastore managed object in vmware tag manager

### DIFF
--- a/plugins/modules/vmware_tag_manager.py
+++ b/plugins/modules/vmware_tag_manager.py
@@ -47,7 +47,7 @@ options:
       description:
       - Type of object to work with.
       required: True
-      choices: [ VirtualMachine, Datacenter, ClusterComputeResource, HostSystem, DistributedVirtualSwitch, DistributedVirtualPortgroup, Datastore ]
+      choices: [ VirtualMachine, Datacenter, ClusterComputeResource, HostSystem, DistributedVirtualSwitch, DistributedVirtualPortgroup, Datastore, ResourcePool ]
       type: str
     object_name:
       description:
@@ -184,6 +184,9 @@ class VmwareTagManager(VmwareRestClient):
         if self.object_type == 'ClusterComputeResource':
             self.managed_object = self.pyv.find_cluster_by_name(self.object_name)
 
+        if self.object_type == 'ResourcePool':
+            self.managed_object = self.pyv.find_resource_pool_by_name(self.object_name)
+
         if self.object_type == 'HostSystem':
             self.managed_object = self.pyv.find_hostsystem_by_name(self.object_name)
 
@@ -305,7 +308,7 @@ def main():
         object_name=dict(type='str', required=True),
         object_type=dict(type='str', required=True, choices=['VirtualMachine', 'Datacenter', 'ClusterComputeResource',
                                                              'HostSystem', 'DistributedVirtualSwitch',
-                                                             'DistributedVirtualPortgroup', 'Datastore']),
+                                                             'DistributedVirtualPortgroup', 'Datastore', 'ResourcePool']),
     )
     module = AnsibleModule(argument_spec=argument_spec)
 

--- a/plugins/modules/vmware_tag_manager.py
+++ b/plugins/modules/vmware_tag_manager.py
@@ -47,7 +47,7 @@ options:
       description:
       - Type of object to work with.
       required: True
-      choices: [ VirtualMachine, Datacenter, ClusterComputeResource, HostSystem, DistributedVirtualSwitch, DistributedVirtualPortgroup, Datastore, ResourcePool, Folder ]
+      choices: [ VirtualMachine, Datacenter, ClusterComputeResource, HostSystem, DistributedVirtualSwitch, DistributedVirtualPortgroup, Datastore, DatastoreCluster, ResourcePool, Folder ]
       type: str
     object_name:
       description:
@@ -184,6 +184,10 @@ class VmwareTagManager(VmwareRestClient):
         if self.object_type == 'Datastore':
             self.managed_object = self.pyv.find_datastore_by_name(self.object_name)
 
+        if self.object_type == 'DatastoreCluster':
+            self.managed_object = self.pyv.find_datastore_cluster_by_name(self.object_name)
+            self.object_type = 'StoragePod'
+
         if self.object_type == 'ClusterComputeResource':
             self.managed_object = self.pyv.find_cluster_by_name(self.object_name)
 
@@ -312,7 +316,7 @@ def main():
         object_type=dict(type='str', required=True, choices=['VirtualMachine', 'Datacenter', 'ClusterComputeResource',
                                                              'HostSystem', 'DistributedVirtualSwitch',
                                                              'DistributedVirtualPortgroup', 'Datastore', 'ResourcePool',
-                                                             'Folder']),
+                                                             'Folder', 'DatastoreCluster']),
     )
     module = AnsibleModule(argument_spec=argument_spec)
 

--- a/plugins/modules/vmware_tag_manager.py
+++ b/plugins/modules/vmware_tag_manager.py
@@ -47,7 +47,7 @@ options:
       description:
       - Type of object to work with.
       required: True
-      choices: [ VirtualMachine, Datacenter, ClusterComputeResource, HostSystem, DistributedVirtualSwitch, DistributedVirtualPortgroup ]
+      choices: [ VirtualMachine, Datacenter, ClusterComputeResource, HostSystem, DistributedVirtualSwitch, DistributedVirtualPortgroup, Datastore ]
       type: str
     object_name:
       description:
@@ -178,6 +178,9 @@ class VmwareTagManager(VmwareRestClient):
         if self.object_type == 'Datacenter':
             self.managed_object = self.pyv.find_datacenter_by_name(self.object_name)
 
+        if self.object_type == 'Datastore':
+            self.managed_object = self.pyv.find_datastore_by_name(self.object_name)
+
         if self.object_type == 'ClusterComputeResource':
             self.managed_object = self.pyv.find_cluster_by_name(self.object_name)
 
@@ -302,7 +305,7 @@ def main():
         object_name=dict(type='str', required=True),
         object_type=dict(type='str', required=True, choices=['VirtualMachine', 'Datacenter', 'ClusterComputeResource',
                                                              'HostSystem', 'DistributedVirtualSwitch',
-                                                             'DistributedVirtualPortgroup']),
+                                                             'DistributedVirtualPortgroup', 'Datastore']),
     )
     module = AnsibleModule(argument_spec=argument_spec)
 

--- a/plugins/modules/vmware_tag_manager.py
+++ b/plugins/modules/vmware_tag_manager.py
@@ -47,7 +47,7 @@ options:
       description:
       - Type of object to work with.
       required: True
-      choices: [ VirtualMachine, Datacenter, ClusterComputeResource, HostSystem, DistributedVirtualSwitch, DistributedVirtualPortgroup, Datastore, ResourcePool ]
+      choices: [ VirtualMachine, Datacenter, ClusterComputeResource, HostSystem, DistributedVirtualSwitch, DistributedVirtualPortgroup, Datastore, ResourcePool, Folder ]
       type: str
     object_name:
       description:
@@ -174,6 +174,9 @@ class VmwareTagManager(VmwareRestClient):
 
         if self.object_type == 'VirtualMachine':
             self.managed_object = self.pyv.get_vm_or_template(self.object_name)
+
+        if self.object_type == 'Folder':
+            self.managed_object = self.pyv.find_folder_by_name(self.object_name)
 
         if self.object_type == 'Datacenter':
             self.managed_object = self.pyv.find_datacenter_by_name(self.object_name)
@@ -308,7 +311,8 @@ def main():
         object_name=dict(type='str', required=True),
         object_type=dict(type='str', required=True, choices=['VirtualMachine', 'Datacenter', 'ClusterComputeResource',
                                                              'HostSystem', 'DistributedVirtualSwitch',
-                                                             'DistributedVirtualPortgroup', 'Datastore', 'ResourcePool']),
+                                                             'DistributedVirtualPortgroup', 'Datastore', 'ResourcePool',
+                                                             'Folder']),
     )
     module = AnsibleModule(argument_spec=argument_spec)
 


### PR DESCRIPTION
##### SUMMARY

Fixes #217 Added Datastore to the list of choices and copied pre-existing logic to apply datastore tags.  Used find_data_store_by_name to locate the datastore in vCenter.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_tag_manager

##### ADDITIONAL INFORMATION
A working example using the library:
```yaml
TASK [tkg-platform-storage : apply storage class tags to datastores] *********************************************************
task path: /root/project-ivy/roles/tkg-platform-storage/tasks/vmware.yml:43
ok: [localhost] => (item=[{'name': 'bronze', 'datastores': ['vmw_nfs_q01lp', 'vmw_nfs_q02lp']}, 'vmw_nfs_q01lp']) => {"ansible_loop_var": "item", "changed": false, "item": [{"datastores": ["vmw_nfs_q01lp", "vmw_nfs_q02lp"], "name": "bronze"}, "vmw_nfs_q01lp"], "tag_status": {"current_tags": ["bronze", "Performance-Silver"], "desired_tags": ["bronze"], "previous_tags": ["bronze", "Performance-Silver"]}}
ok: [localhost] => (item=[{'name': 'bronze', 'datastores': ['vmw_nfs_q01lp', 'vmw_nfs_q02lp']}, 'vmw_nfs_q02lp']) => {"ansible_loop_var": "item", "changed": false, "item": [{"datastores": ["vmw_nfs_q01lp", "vmw_nfs_q02lp"], "name": "bronze"}, "vmw_nfs_q02lp"], "tag_status": {"current_tags": ["bronze", "Performance-Silver"], "desired_tags": ["bronze"], "previous_tags": ["bronze", "Performance-Silver"]}}
ok: [localhost] => (item=[{'name': 'silver', 'datastores': ['vmw_iscsi_q01lp', 'vmw_iscsi_q02lp', 'vmw_iscsi_q03lp']}, 'vmw_iscsi_q01lp']) => {"ansible_loop_var": "item", "changed": false, "item": [{"datastores": ["vmw_iscsi_q01lp", "vmw_iscsi_q02lp", "vmw_iscsi_q03lp"], "name": "silver"}, "vmw_iscsi_q01lp"], "tag_status": {"current_tags": ["Performance-Gold", "silver"], "desired_tags": ["silver"], "previous_tags": ["Performance-Gold", "silver"]}}
ok: [localhost] => (item=[{'name': 'silver', 'datastores': ['vmw_iscsi_q01lp', 'vmw_iscsi_q02lp', 'vmw_iscsi_q03lp']}, 'vmw_iscsi_q02lp']) => {"ansible_loop_var": "item", "changed": false, "item": [{"datastores": ["vmw_iscsi_q01lp", "vmw_iscsi_q02lp", "vmw_iscsi_q03lp"], "name": "silver"}, "vmw_iscsi_q02lp"], "tag_status": {"current_tags": ["Performance-Gold", "silver"], "desired_tags": ["silver"], "previous_tags": ["Performance-Gold", "silver"]}}
ok: [localhost] => (item=[{'name': 'silver', 'datastores': ['vmw_iscsi_q01lp', 'vmw_iscsi_q02lp', 'vmw_iscsi_q03lp']}, 'vmw_iscsi_q03lp']) => {"ansible_loop_var": "item", "changed": false, "item": [{"datastores": ["vmw_iscsi_q01lp", "vmw_iscsi_q02lp", "vmw_iscsi_q03lp"], "name": "silver"}, "vmw_iscsi_q03lp"], "tag_status": {"current_tags": ["Performance-Gold", "silver"], "desired_tags": ["silver"], "previous_tags": ["Performance-Gold", "silver"]}}
ok: [localhost] => (item=[{'name': 'gold', 'datastores': ['vmw_iscsi_q01hp', 'vmw_iscsi_q02hp']}, 'vmw_iscsi_q01hp']) => {"ansible_loop_var": "item", "changed": false, "item": [{"datastores": ["vmw_iscsi_q01hp", "vmw_iscsi_q02hp"], "name": "gold"}, "vmw_iscsi_q01hp"], "tag_status": {"current_tags": ["gold"], "desired_tags": ["gold"], "previous_tags": ["gold"]}}
ok: [localhost] => (item=[{'name': 'gold', 'datastores': ['vmw_iscsi_q01hp', 'vmw_iscsi_q02hp']}, 'vmw_iscsi_q02hp']) => {"ansible_loop_var": "item", "changed": false, "item": [{"datastores": ["vmw_iscsi_q01hp", "vmw_iscsi_q02hp"], "name": "gold"}, "vmw_iscsi_q02hp"], "tag_status": {"current_tags": ["gold"], "desired_tags": ["gold"], "previous_tags": ["gold"]}}
ok: [localhost] => (item=[{'name': 'platinum', 'datastores': ['vmw_vsan_v01hp']}, 'vmw_vsan_v01hp']) => {"ansible_loop_var": "item", "changed": false, "item": [{"datastores": ["vmw_vsan_v01hp"], "name": "platinum"}, "vmw_vsan_v01hp"], "tag_status": {"current_tags": ["platinum"], "desired_tags": ["platinum"], "previous_tags": ["platinum"]}}
META: ran handlers
META: ran handlers
```
