### PR TITLE
VMware: Added param content library in definition main

### DIFF
--- a/changelogs/fragments/219-vmware_content_deploy_template_added_param_content_library.yml
+++ b/changelogs/fragments/219-vmware_content_deploy_template_added_param_content_library.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_content_deploy_template - Added param content_library to the main function

--- a/plugins/modules/vmware_content_deploy_template.py
+++ b/plugins/modules/vmware_content_deploy_template.py
@@ -236,6 +236,8 @@ def main():
         state=dict(type='str', default='present',
                    choices=['present', 'poweredon']),
         template=dict(type='str', aliases=['template_src'], required=True),
+        content_library=dict(type='str', aliases=[
+                             'content_library_src'], required=False),
         name=dict(type='str', required=True, aliases=['vm_name']),
         datacenter=dict(type='str', required=True),
         datastore=dict(type='str', required=True),


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/vmware/pull/231

##### SUMMARY
Added the param content_library to the main function. The value of content library is not getting captured currently. This will fix it.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
vmware_content_deploy_template.py

##### ADDITIONAL INFORMATION
No change in the output
