### PR TITLE
vmware_dvs_portgroup_info: show the key value

### DIFF
--- a/changelogs/fragments/vmware_dvs_portgroup_info_key.yaml
+++ b/changelogs/fragments/vmware_dvs_portgroup_info_key.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- vmware_dvs_portgroup_info - Include the value of the Portgroup ``key`` in the result

--- a/plugins/modules/vmware_dvs_portgroup_info.py
+++ b/plugins/modules/vmware_dvs_portgroup_info.py
@@ -238,6 +238,7 @@ class DVSPortgroupInfoManager(PyVmomi):
                     port_policy=port_policy,
                     network_policy=network_policy,
                     vlan_info=vlan_info,
+                    key=dvs_pg.key,
                 )
                 result[dvs.name].append(dvpg_details)
 

--- a/tests/integration/targets/vmware_dvs_portgroup_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_dvs_portgroup_info/tasks/main.yml
@@ -54,3 +54,4 @@
 - assert:
     that:
       - "dvs_results_0002['dvs_portgroup_info']['DVS0'] is defined"
+      - dvs_results_0002['dvs_portgroup_info']['DVS0'][0].key


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/vmware/pull/231

Include the value of the Portgroup `key` in the result.