### PR TITLE
dvswitch: collect the UUID

### DIFF
--- a/changelogs/fragments/vmware_dvswitch_uuid.yaml
+++ b/changelogs/fragments/vmware_dvswitch_uuid.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - vmware_dvswitch now returns the UUID of the switch
+  - vmware_dvswitch_info also returns the switch UUID

--- a/plugins/modules/vmware_dvswitch.py
+++ b/plugins/modules/vmware_dvswitch.py
@@ -396,6 +396,7 @@ class VMwareDvSwitch(PyVmomi):
             # Set Health Check config
             results['health_check_vlan'] = self.health_check_vlan
             results['health_check_teaming'] = self.health_check_teaming
+            results['uuid'] = self.dvs.uuid
             result = self.check_health_check_config(self.dvs.config.healthCheckConfig)
             changed_health_check = result[1]
             if changed_health_check:
@@ -667,6 +668,7 @@ class VMwareDvSwitch(PyVmomi):
                         self.module.fail_json(msg="Failed to update DVS version : %s" % to_native(invalid_argument))
         else:
             message = "DVS already configured properly"
+        results['uuid'] = self.dvs.uuid
         results['changed'] = changed
         results['result'] = message
 

--- a/plugins/modules/vmware_dvswitch_info.py
+++ b/plugins/modules/vmware_dvswitch_info.py
@@ -169,7 +169,8 @@ distributed_virtual_switches:
               },
               "privateVlan": []
             }
-          }
+          },
+          "uuid": "50 30 99 9c a7 60 8a 4f-05 9f e7 b5 da df 8f 17"
         }
       ]
 '''
@@ -268,8 +269,10 @@ class VMwareDvSwitchInfoManager(PyVmomi):
                         'healthCheck': health_check
                     },
                     'hosts': host_members,
-                    'folder': switch_obj.parent.name
-                }
+                    'folder': switch_obj.parent.name,
+                    'name': switch_obj.name,
+                },
+                'uuid': switch_obj.uuid,
             })
 
         self.module.exit_json(changed=False, distributed_virtual_switches=distributed_virtual_switches)


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/527

`vmware_dvswitch` and `vmware_dvswitch_info` now collect the `UUID` of the switch.

The switch UUID is an important information for those who use the vSphere REST API.