### PR TITLE
VMware: Fix to be set default parameter for runtime_settings to runtime_settings

### DIFF
--- a/changelogs/fragments/225-vmware_vcenter_settings.yml
+++ b/changelogs/fragments/225-vmware_vcenter_settings.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_vcenter_settings - Fixed when runtime_settings parameters not defined occur error(https://github.com/ansible/ansible/issues/66713)

--- a/plugins/modules/vmware_vcenter_settings.py
+++ b/plugins/modules/vmware_vcenter_settings.py
@@ -224,6 +224,11 @@ class VmwareVcenterSettings(PyVmomi):
         if not self.is_vcenter():
             self.module.fail_json(msg="You have to connect to a vCenter server!")
 
+        self.option_manager = self.content.setting
+
+    def get_default_setting_value(self, setting_key):
+        return self.option_manager.QueryOptions(name=setting_key)[0].value
+
     def ensure(self):
         """Manage settings for a vCenter server"""
         result = dict(changed=False, msg='')
@@ -232,9 +237,20 @@ class VmwareVcenterSettings(PyVmomi):
         db_task_retention = self.params['database'].get('task_retention')
         db_event_cleanup = self.params['database'].get('event_cleanup')
         db_event_retention = self.params['database'].get('event_retention')
-        runtime_unique_id = self.params['runtime_settings'].get('unique_id')
-        runtime_managed_address = self.params['runtime_settings'].get('managed_address')
-        runtime_server_name = self.params['runtime_settings'].get('vcenter_server_name')
+
+        # runtime default value
+        runtime_unique_id = self.get_default_setting_value('instance.id')
+        runtime_managed_address = self.get_default_setting_value('VirtualCenter.ManagedIP')
+        runtime_server_name = self.get_default_setting_value('VirtualCenter.InstanceName')
+
+        if self.params['runtime_settings']:
+            if self.params['runtime_settings'].get('unique_id') is not None:
+                runtime_unique_id = self.params['runtime_settings'].get('unique_id')
+            if self.params['runtime_settings'].get('managed_address') is not None:
+                runtime_managed_address = self.params['runtime_settings'].get('managed_address')
+            if self.params['runtime_settings'].get('vcenter_server_name') is not None:
+                runtime_server_name = self.params['runtime_settings'].get('vcenter_server_name')
+
         directory_timeout = self.params['user_directory'].get('timeout')
         directory_query_limit = self.params['user_directory'].get('query_limit')
         directory_query_limit_size = self.params['user_directory'].get('query_limit_size')
@@ -285,8 +301,7 @@ class VmwareVcenterSettings(PyVmomi):
         result['timeout_long_operations'] = timeout_long_operations
         result['logging_options'] = logging_options
         change_option_list = []
-        option_manager = self.content.setting
-        for setting in option_manager.setting:
+        for setting in self.option_manager.setting:
             # Database
             if setting.key == 'VirtualCenter.MaxDBConnection' and setting.value != db_max_connections:
                 changed = True
@@ -550,7 +565,7 @@ class VmwareVcenterSettings(PyVmomi):
             message += changed_suffix
             if not self.module.check_mode:
                 try:
-                    option_manager.UpdateOptions(changedValue=change_option_list)
+                    self.option_manager.UpdateOptions(changedValue=change_option_list)
                 except (vmodl.fault.SystemError, vmodl.fault.InvalidArgument) as invalid_argument:
                     self.module.fail_json(
                         msg="Failed to update option(s) as one or more OptionValue contains an invalid value: %s" %

--- a/tests/integration/targets/vmware_vcenter_settings/aliases
+++ b/tests/integration/targets/vmware_vcenter_settings/aliases
@@ -1,5 +1,3 @@
-shippable/vcenter/group2
 cloud/vcenter
-needs/target/prepare_vmware_tests
+unsupported
 zuul/vmware/vcenter_only
-zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_vcenter_settings/aliases
+++ b/tests/integration/targets/vmware_vcenter_settings/aliases
@@ -1,3 +1,3 @@
 cloud/vcenter
-unsupported
+needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only

--- a/tests/integration/targets/vmware_vcenter_settings/tasks/main.yml
+++ b/tests/integration/targets/vmware_vcenter_settings/tasks/main.yml
@@ -81,3 +81,16 @@
   register: all_settings_results
 
 - debug: var=all_settings_results
+
+- name: Configure settings with out runtime_settings parameter
+  vmware_vcenter_settings:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
+    mail:
+      server: mail.example.local
+      sender: vcenter@{{ inventory_hostname }}
+  register: without_runtime_settings_results
+
+- debug: var=without_runtime_settings_results


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/vmware/pull/226

##### SUMMARY
When runtime_settings parameter not defined or some parameters not set in runtime_settings, fix to be set default parameters for runtime_settings to runtime_settings parameters.

fixes: https://github.com/ansible/ansible/issues/66713

Original PR: https://github.com/ansible/ansible/pull/67670

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
vmware_vcenter_settings

##### ADDITIONAL INFORMATION
tested on vCenter 6.7
