### PR TITLE
vmware_category: fix a typo in test-suite

### DIFF
--- a/tests/integration/targets/vmware_category/tasks/associable_obj_types.yml
+++ b/tests/integration/targets/vmware_category/tasks/associable_obj_types.yml
@@ -3,7 +3,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 - name: Define required data
-  set_facts:
+  set_fact:
     cat_data:
     - name: 'Folder'
       result: 'Folder'


### PR DESCRIPTION
`set_facts` become `set_fact`.