### PR TITLE
Remove action_groups_redirection from meta/runtime.yml

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -127,7 +127,3 @@ action_groups:
   - vmware_vswitch_info
   - vsphere_copy
   - vsphere_file
-
-action_groups_redirection:
-  vmware:
-    redirect: vmware


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/vmware/pull/231

##### SUMMARY
This field isn't being added for Ansible 2.10

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request