### PR TITLE
vmware_category: arguments_spec, elemetns as str

### DIFF
--- a/plugins/modules/vmware_category.py
+++ b/plugins/modules/vmware_category.py
@@ -341,7 +341,7 @@ def main():
                 'Host Network', 'Opaque Network', 'Resource Pool', 'vApp',
                 'Virtual Machine',
             ],
-            elements=str,
+            elements='str',
         ),
     )
     module = AnsibleModule(argument_spec=argument_spec)


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/524
Depends-On: https://github.com/ansible-collections/vmware/pull/231

`elements` key should be a `string` instance, not a `type` object. We face the problem since https://github.com/ansible/ansible/pull/57145.

Otherwise, we hit the following error:

```
The full traceback is:
  File "/tmp/ansible_vmware_category_payload_w4g0m32x/ansible_vmware_category_payload.zip/ansible/module_utils/basic.py", line 1775, in _handle_elements
    validated_params.append(type_checker(value, **kwargs))
fatal: [testhost]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "associable_object_types": [
                "Folder"
            ],
            "category_cardinality": "multiple",
            "category_description": "Folder",
            "category_name": "Folder",
            "hostname": "vcenter.test",
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "port": 443,
            "protocol": "https",
            "state": "present",
            "username": "administrator@vsphere.local",
            "validate_certs": false
        }
    },
    "msg": "Elements value for option associable_object_types is of type <class 'str'> and we were unable to convert to str: 'param' is an invalid keyword argument for str()"
}
```