### PR TITLE
import changelog fragments from ansible/ansible

### DIFF
--- a/changelogs/fragments/57185-fix_vmware_modules_py_pre2.79.yaml
+++ b/changelogs/fragments/57185-fix_vmware_modules_py_pre2.79.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware - Ensure we can use the modules with Python < 2.7.9 or RHEL/CentOS < 7.4, this as soon as ``validate_certs`` is disabled.

--- a/changelogs/fragments/57535-vmware_vcenter_statistics_corner-cases.yml
+++ b/changelogs/fragments/57535-vmware_vcenter_statistics_corner-cases.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- vmware_vcenter_statistics - Fix some corner cases like increasing some interval and decreasing another at the same time.

--- a/changelogs/fragments/58824-vmware_cluster_ha-advanced-settings.yml
+++ b/changelogs/fragments/58824-vmware_cluster_ha-advanced-settings.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- vmware_cluster_ha - Implemented HA advanced settings (https://github.com/ansible/ansible/issues/61421)

--- a/changelogs/fragments/58824-vmware_dvs_portgroup-implement-portgroup-updates.yml
+++ b/changelogs/fragments/58824-vmware_dvs_portgroup-implement-portgroup-updates.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- vmware_dvs_portgroup - Implemented configuration changes on an existing Distributed vSwitch portgroup.

--- a/changelogs/fragments/62083-vmware-internal_results.yml
+++ b/changelogs/fragments/62083-vmware-internal_results.yml
@@ -1,0 +1,6 @@
+minor_changes:
+    - vmware_datastore_maintenancemode now returns datastore_status instead of Ansible internal key results (https://github.com/ansible/ansible/issues/62083).
+    - vmware_host_kernel_manager now returns host_kernel_status instead of Ansible internal key results (https://github.com/ansible/ansible/issues/62083).
+    - vmware_host_ntp now returns host_ntp_status instead of Ansible internal key results (https://github.com/ansible/ansible/issues/62083).
+    - vmware_host_service_manager now returns host_service_status instead of Ansible internal key results (https://github.com/ansible/ansible/issues/62083).
+    - vmware_tag now returns tag_status instead of Ansible internal key results (https://github.com/ansible/ansible/issues/62083).

--- a/changelogs/fragments/62188-VMware-Guest-Support-latest-version-while-upgrading-VM-hardware.yml
+++ b/changelogs/fragments/62188-VMware-Guest-Support-latest-version-while-upgrading-VM-hardware.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- vmware_guest - Add ability to upgrade the guest hardware version to latest fix issue (https://github.com/ansible/ansible/issues/56273).

--- a/changelogs/fragments/62616-vmware_cluster_ha-fix-documentation.yml
+++ b/changelogs/fragments/62616-vmware_cluster_ha-fix-documentation.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- vmware_cluster_ha - Remove a wrong parameter from an example in the documentation.

--- a/changelogs/fragments/62772-vmware_vmkernel_info-fix.yml
+++ b/changelogs/fragments/62772-vmware_vmkernel_info-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Check for virtualNicManager in Esxi host system before accessing properties in vmware_vmkernel_info (https://github.com/ansible/ansible/issues/62772).

--- a/changelogs/fragments/62810-Vmware-Guest-Allow-DashInWindowsServerDNSName.yml
+++ b/changelogs/fragments/62810-Vmware-Guest-Allow-DashInWindowsServerDNSName.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- vmware_guest - Allow '-' (Dash) special char in windows DNS name.

--- a/changelogs/fragments/62916-add_properties_option_to_vmware_host_facts.yml
+++ b/changelogs/fragments/62916-add_properties_option_to_vmware_host_facts.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_host_facts - added ``properties`` and ``schema`` options.

--- a/changelogs/fragments/629400-add_properties_option_to_vmware_datastore_info.yml
+++ b/changelogs/fragments/629400-add_properties_option_to_vmware_datastore_info.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_datastore_info - added ``properties`` and ``schema`` options.

--- a/changelogs/fragments/63740-vmware_guest_disk_filename_destroy.yaml
+++ b/changelogs/fragments/63740-vmware_guest_disk_filename_destroy.yaml
@@ -1,0 +1,5 @@
+---
+
+minor_changes:
+  - vmware_guest_disk - Add `destroy` option which allows to remove a disk without deleting the VMDK file.
+  - vmware_guest_disk - Add `filename` option which allows to create a disk from an existing VMDK.

--- a/changelogs/fragments/63741-do_not_search_for_vmdk_if_filename_defined.yaml
+++ b/changelogs/fragments/63741-do_not_search_for_vmdk_if_filename_defined.yaml
@@ -1,0 +1,4 @@
+---
+
+minor_changes:
+  - vmware_guest - Don't search for VMDK if filename is defined.

--- a/changelogs/fragments/64399_vmware_guest.yml
+++ b/changelogs/fragments/64399_vmware_guest.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Handle slashes in VMware network name (https://github.com/ansible/ansible/issues/64399).

--- a/changelogs/fragments/64458-vmware_host_dns.yaml
+++ b/changelogs/fragments/64458-vmware_host_dns.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+- vmware_host_dns - New module replacing vmware_dns_config with increased functionality.
+deprecated_features:
+- vmware_dns_config - Deprecate in favour of new module vmware_host_dns.

--- a/changelogs/fragments/65154-vmware_datastore_cluster-configure-dns.yml
+++ b/changelogs/fragments/65154-vmware_datastore_cluster-configure-dns.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- vmware_datastore_cluster - Added basic SDRS configuration (https://github.com/ansible/ansible/issues/65154).

--- a/changelogs/fragments/65715-vmware-content-deploy-template-fix-cluster.yml
+++ b/changelogs/fragments/65715-vmware-content-deploy-template-fix-cluster.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "`vmware_content_deploy_template`'s `cluster` argument no longer fails with an error message about resource pools."

--- a/changelogs/fragments/65733-fix-vmware-guest-properties-doc.yaml
+++ b/changelogs/fragments/65733-fix-vmware-guest-properties-doc.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_guest - Updated reference link to vapp_properties property

--- a/changelogs/fragments/65765-vmware_tag_manager.yml
+++ b/changelogs/fragments/65765-vmware_tag_manager.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Added support to vmware_tag_manager module for specifying tag and category as dict if any of the name contains colon (https://github.com/ansible/ansible/issues/65765).

--- a/changelogs/fragments/65922-filter-VMs-of-Same-name-on-the-basis-of-folder.yml
+++ b/changelogs/fragments/65922-filter-VMs-of-Same-name-on-the-basis-of-folder.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Vmware Fix for Create overwrites a VM of same name even when the folder is different(https://github.com/ansible/ansible/issues/43161)

--- a/changelogs/fragments/65968-vmware_guest_network.yml
+++ b/changelogs/fragments/65968-vmware_guest_network.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- In vmware_guest_network module use appropriate network while creating or reconfiguring (https://github.com/ansible/ansible/issues/65968).

--- a/changelogs/fragments/65997-vmware_guest-exclude-dvswitch-name-from-os-customization.yml
+++ b/changelogs/fragments/65997-vmware_guest-exclude-dvswitch-name-from-os-customization.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_guest - Exclude dvswitch_name from triggering guest os customization.

--- a/changelogs/fragments/66217-vmware_cluster_drs-advanced-settings.yml
+++ b/changelogs/fragments/66217-vmware_cluster_drs-advanced-settings.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- vmware_cluster_drs - Implemented DRS advanced settings (https://github.com/ansible/ansible/issues/66217)

--- a/changelogs/fragments/66692-vmware_host_vmhba_info_fix_63045.yml
+++ b/changelogs/fragments/66692-vmware_host_vmhba_info_fix_63045.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_host_vmhba_info - fixed node_wwn and port_wwn for FC HBA to hexadecimal format(https://github.com/ansible/ansible/issues/63045).

--- a/changelogs/fragments/67221-vmware-guest-disk-storage-drs-fix.yml
+++ b/changelogs/fragments/67221-vmware-guest-disk-storage-drs-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- return correct datastore cluster placement recommendations during when adding disk using the vmware_guest_disk module

--- a/changelogs/fragments/67282-remove_options_from_some_vmware_modules_that_aren't_used_in_the_code.yml
+++ b/changelogs/fragments/67282-remove_options_from_some_vmware_modules_that_aren't_used_in_the_code.yml
@@ -1,0 +1,4 @@
+removed_features:
+  - vmware_guest_find - Removed deprecated ``datacenter`` option
+  - vmware_vmkernel - Removed deprecated ``ip_address`` option; use sub-option ip_address in the network option instead
+  - vmware_vmkernel - Removed deprecated ``subnet_mask`` option; use sub-option subnet_mask in the network option instead

--- a/changelogs/fragments/67303-vmware_host_firewall_manager-fix_ip_specific_firewall_rules_for_python2.yml
+++ b/changelogs/fragments/67303-vmware_host_firewall_manager-fix_ip_specific_firewall_rules_for_python2.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- vmware_host_firewall_manager - Fixed creating IP specific firewall rules with Python 2 (https://github.com/ansible/ansible/issues/67303)

--- a/changelogs/fragments/67615-vmware_host_service_info_fix.yml
+++ b/changelogs/fragments/67615-vmware_host_service_info_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Handle NoneType error when accessing service system info in vmware_host_service_info module (https://github.com/ansible/ansible/issues/67615).

--- a/changelogs/fragments/typo_fix_vmware_guest_powerstate.yml
+++ b/changelogs/fragments/typo_fix_vmware_guest_powerstate.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fixed typo in vmware_guest_powerstate module (https://github.com/ansible/ansible/issues/65161).

--- a/changelogs/fragments/vmware-module_fragments-group.yml
+++ b/changelogs/fragments/vmware-module_fragments-group.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - A `vmware` module_defaults group has been added to simplify parameters for
+    multiple VMware tasks. This group includes all VMware modules.

--- a/changelogs/fragments/vmware-only-add-configured-interfaces.yml
+++ b/changelogs/fragments/vmware-only-add-configured-interfaces.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - vmware.py - Only add configured network interfaces to facts.

--- a/changelogs/fragments/vmware_cluster_info_hosts.yml
+++ b/changelogs/fragments/vmware_cluster_info_hosts.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Return additional information about hosts inside the cluster using vmware_cluster_info.

--- a/changelogs/fragments/vmware_export_ovf.yaml
+++ b/changelogs/fragments/vmware_export_ovf.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - vmware_export_ovf - timeout value is actually in seconds, not minutes
+  - vmware_export_ovf - increase default timeout to 30s

--- a/changelogs/fragments/vmware_guest.yaml
+++ b/changelogs/fragments/vmware_guest.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Added a timeout parameter `wait_for_ip_address_timeout` for `wait_for_ip_address` for longer-running tasks in vmware_guest.

--- a/changelogs/fragments/vmware_guest_custom_attributes.yml
+++ b/changelogs/fragments/vmware_guest_custom_attributes.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - vmware_guest_custom_attributes does not require VM name (https://github.com/ansible/ansible/issues/63222).

--- a/changelogs/fragments/vmware_guest_disk_info_disk_mode.yml
+++ b/changelogs/fragments/vmware_guest_disk_info_disk_mode.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - Added missing backing_disk_mode information about disk which was removed by mistake in vmware_guest_disk_info.

--- a/changelogs/fragments/vmware_guest_tools_wait_time.yaml
+++ b/changelogs/fragments/vmware_guest_tools_wait_time.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - vmware_guest_tools_wait now exposes a ``timeout`` parameter that allow the user to adjust the timeout (second).

--- a/changelogs/fragments/vmware_host_firewall_manager_fix_61332.yaml
+++ b/changelogs/fragments/vmware_host_firewall_manager_fix_61332.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+- vmware_host_firewall_manager - Ensure we can set rule with no ``allowed_hosts`` key (https://github.com/ansible/ansible/issues/61332)
+minor_changes:
+- vmware_host_firewall_manager - ``allowed_hosts`` excpects a dict as parameter, list is deprecated

--- a/changelogs/fragments/vmware_host_lockdown_typo_fix.yml
+++ b/changelogs/fragments/vmware_host_lockdown_typo_fix.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Correct datatype for state in vmware_host_lockdown module.

--- a/changelogs/fragments/vmware_httpapi_fix.yml
+++ b/changelogs/fragments/vmware_httpapi_fix.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Minor typo fixes in vmware_httpapi related modules and module_utils.

--- a/changelogs/fragments/vmware_vm_inventory_port.yml
+++ b/changelogs/fragments/vmware_vm_inventory_port.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- vmware_vm_inventory inventory plugin, use the port value while connecting to vCenter (https://github.com/ansible/ansible/issues/64096).


### PR DESCRIPTION
We didn't migrate the changelog fragments during the transition. Since
these changes are yet to be published, it makes sense to import
them in the collection.
