### PR TITLE
vcsim/systemd: use the full path to vcsim

### DIFF
--- a/tests/integration/targets/prepare_vmware_tests/tasks/init_vcsim_with_systemd.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/init_vcsim_with_systemd.yml
@@ -14,7 +14,7 @@
   become: true
 
 - name: start vcsim (all dressed)
-  command: "systemd-run --unit=ansible-vmware-govcsim --remain-after-exit vcsim -l 127.0.0.1:443 -app=0 -cluster=1 -dc=1 -ds=2 -folder=1 -host=3 -pg=1 -pod=1 -pool=1 -vm=2"
+  command: "systemd-run --unit=ansible-vmware-govcsim --remain-after-exit /usr/local/bin/vcsim -l 127.0.0.1:443 -app=0 -cluster=1 -dc=1 -ds=2 -folder=1 -host=3 -pg=1 -pod=1 -pool=1 -vm=2"
   become: true
 
 - set_fact:


### PR DESCRIPTION
Call `systemd-run` with the full path of the `vcsim` binary. Our CI uses
`/usr/local/bin` and the directory in now necessary in `$PATH` by
default.