### PR TITLE
Fail early with more info when all templates failed

### DIFF
--- a/changelogs/fragments/253-inventory_hostnames_fail_message.yml
+++ b/changelogs/fragments/253-inventory_hostnames_fail_message.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- vmware_vm_inventory inventory plugin, raise more descriptive error when all template strings in ``hostnames`` fail.

--- a/plugins/inventory/vmware_vm_inventory.py
+++ b/plugins/inventory/vmware_vm_inventory.py
@@ -697,6 +697,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     def _get_hostname(self, properties, hostnames, strict=False):
         hostname = None
+        errors = []
 
         for preference in hostnames:
             try:
@@ -704,8 +705,18 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             except Exception as e:  # pylint: disable=broad-except
                 if strict:
                     raise AnsibleError("Could not compose %s as hostnames - %s" % (preference, to_native(e)))
+                else:
+                    errors.append(
+                        (preference, str(e))
+                    )
             if hostname:
                 return to_text(hostname)
+
+        raise AnsibleError(
+            'Could not template any hostname for host, errors for each preference: %s' % (
+                ', '.join(['%s: %s' % (pref, err) for pref, err in errors])
+            )
+        )
 
     def _can_add_host(self, host_filters, host_properties, host, strict=False):
         can_add_host = True


### PR DESCRIPTION
##### SUMMARY
This gives more detail when parsing failed for debugging.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/inventory/vmware_vm_inventory.py

##### ADDITIONAL INFORMATION
A null hostname is not accepted by Ansible.

So the decision for the inventory plugin is that it should either error when no template for hostname is successful, or omit those hosts. Omitting them would be bad, and wouldn't solve the problem of figuring out how to fix it.

Previously, these situations hit this error:

```
[WARNING]:  * Failed to parse /Users/alancoding/Documents/repos/ansible-inventory-file-examples/private/vmware/aka.vmware.yaml with auto plugin: Invalid empty host name provided:
None
  File "/Users/alancoding/Documents/repos/ansible/lib/ansible/inventory/manager.py", line 289, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/Users/alancoding/Documents/repos/ansible/lib/ansible/plugins/inventory/auto.py", line 58, in parse
    plugin.parse(inventory, loader, path, cache=cache)
  File "/Users/alancoding/Documents/tower/awx/plugins/collections/ansible_collections/community/vmware/plugins/inventory/vmware_vm_inventory.py", line 610, in parse
    cacheable_results = self._populate_from_source()
  File "/Users/alancoding/Documents/tower/awx/plugins/collections/ansible_collections/community/vmware/plugins/inventory/vmware_vm_inventory.py", line 695, in _populate_from_source
    self._populate_host_properties(host_properties, host)
  File "/Users/alancoding/Documents/tower/awx/plugins/collections/ansible_collections/community/vmware/plugins/inventory/vmware_vm_inventory.py", line 726, in _populate_host_properties
    self.inventory.add_host(host)
  File "/Users/alancoding/Documents/repos/ansible/lib/ansible/inventory/data.py", line 229, in add_host
    raise AnsibleError("Invalid empty host name provided: %s" % host)
```

I created an inventory file with this:

```yaml
plugin: community.vmware.vmware_vm_inventory
...
hostnames:
  - 'config.name + "_" + config.uuid'
  - 'foo.bar'
```

And that yields this kind of error:

```
[WARNING]:  * Failed to parse /Users/alancoding/Documents/repos/ansible-inventory-file-examples/private/vmware/aka.vmware.yaml with auto plugin: Could not template any hostname for
host, errors for each preference: config.name + "_" + config.uuid: 'dict object' has no attribute 'name', foo.bar: 'foo' is undefined
  File "/Users/alancoding/Documents/repos/ansible/lib/ansible/inventory/manager.py", line 289, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/Users/alancoding/Documents/repos/ansible/lib/ansible/plugins/inventory/auto.py", line 58, in parse
    plugin.parse(inventory, loader, path, cache=cache)
  File "/Users/alancoding/Documents/tower/awx/plugins/collections/ansible_collections/community/vmware/plugins/inventory/vmware_vm_inventory.py", line 610, in parse
    cacheable_results = self._populate_from_source()
  File "/Users/alancoding/Documents/tower/awx/plugins/collections/ansible_collections/community/vmware/plugins/inventory/vmware_vm_inventory.py", line 689, in _populate_from_source
    host = self._get_hostname(host_properties, hostnames, strict=strict)
  File "/Users/alancoding/Documents/tower/awx/plugins/collections/ansible_collections/community/vmware/plugins/inventory/vmware_vm_inventory.py", line 718, in _get_hostname
    ', '.join(['%s: %s' % (pref, err) for pref, err in errors])
```

I can't figure out a _great_ way to format this, because people have different feelings about `\n` in error text. So I am leaving it like this, hopefully good enough.
