### PR TITLE
vmware_content_deploy_ovf_template: fix import

### DIFF
--- a/plugins/modules/vmware_content_deploy_ovf_template.py
+++ b/plugins/modules/vmware_content_deploy_ovf_template.py
@@ -116,8 +116,8 @@ vm_deploy_info:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.vmware_rest_client import VmwareRestClient
-from ansible.module_utils.vmware import PyVmomi
+from ansible_collections.community.vmware.plugins.module_utils.vmware_rest_client import VmwareRestClient
+from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi
 
 HAS_VAUTOMATION_PYTHON_SDK = False
 try:


### PR DESCRIPTION
Import `vmware_rest_client` and `vmware` from within the collection,
not the one from ansible core.

No changelog because the problem was not part of any official release.