### PR TITLE
clean up the 1.0.0 changelog fragments

### DIFF
--- a/changelogs/fragments/109-vmware_host_logbundle.yml
+++ b/changelogs/fragments/109-vmware_host_logbundle.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - vmware_host_logbundle - new code module for a new feature for ESXi support log bundle download operation

--- a/changelogs/fragments/110-vmware_host_logbundle_info.yml
+++ b/changelogs/fragments/110-vmware_host_logbundle_info.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - vmware_host_logbundle_info - new code module for a new feature for getting manifests  for ESXi support log bundle

--- a/changelogs/fragments/113_vmware_content_deploy_ovf_template.yml
+++ b/changelogs/fragments/113_vmware_content_deploy_ovf_template.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- add vmware_content_deploy_ovf_template module for creating VMs from OVF templates

--- a/changelogs/fragments/121-vpsan_session-reduce-complexity.yaml
+++ b/changelogs/fragments/121-vpsan_session-reduce-complexity.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-- vmware_vspan_session - Extract repeated code and reduce complexity of function.

--- a/changelogs/fragments/129_vmware_vm_inventory.yml
+++ b/changelogs/fragments/129_vmware_vm_inventory.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- VMware Guest Inventory plugin enhancements and features.

--- a/changelogs/fragments/141_Correct_doc_of_vmware_local_role_info.yaml
+++ b/changelogs/fragments/141_Correct_doc_of_vmware_local_role_info.yaml
@@ -1,2 +1,0 @@
-minor_changes:
-- Correct example from doc of `vmware_local_role_info.py` to match the change of returned structure.

--- a/changelogs/fragments/145-vmware_dvs_portgroup_find-integer-cast.yaml
+++ b/changelogs/fragments/145-vmware_dvs_portgroup_find-integer-cast.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-- vmware_dvs_portgroup_find - Cast variable to integer for comparison.

--- a/changelogs/fragments/149-remove-duplicate-checks.yaml
+++ b/changelogs/fragments/149-remove-duplicate-checks.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-- vmware_vmkernel - Remove duplicate checks.

--- a/changelogs/fragments/153-vmware_guest.yml
+++ b/changelogs/fragments/153-vmware_guest.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - vmware_guest - add support hardware version 17 for vSphere 7.0 

--- a/changelogs/fragments/154_update_doc.yml
+++ b/changelogs/fragments/154_update_doc.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- Update README.md for installing any third party required Python libraries using pip (https://github.com/ansible-collections/vmware/issues/154).

--- a/changelogs/fragments/166-vmware_deploy_ovf.yml
+++ b/changelogs/fragments/166-vmware_deploy_ovf.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - vmware_deploy_ovf - Fixed ova deploy error occur if vm exists

--- a/changelogs/fragments/183_vmware_host_facts.yml
+++ b/changelogs/fragments/183_vmware_host_facts.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- vmware_host_facts - handle facts when ESXi hostsystem is poweredoff (https://github.com/ansible-collections/vmware/issues/183).

--- a/changelogs/fragments/185-make_vnics_optional_for_dvs.yml
+++ b/changelogs/fragments/185-make_vnics_optional_for_dvs.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - Made vmnics attributes optional when creating DVS as they are optional on the API and GUI as well.

--- a/changelogs/fragments/188-vmware_content_deploy_template-specify_content_library_name.yml
+++ b/changelogs/fragments/188-vmware_content_deploy_template-specify_content_library_name.yml
@@ -1,3 +1,0 @@
-minor_changes:
-  - vmware_content_deploy_template - added new field "content_library" to search template inside the specified content library.
-  - vmware_rest_client - Added a new definition get_library_item_from_content_library_name.

--- a/changelogs/fragments/197_vmware_category.yml
+++ b/changelogs/fragments/197_vmware_category.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- vmware_category - fix associable datatypes (https://github.com/ansible-collections/vmware/issues/197).

--- a/changelogs/fragments/214-add-disk-sharing.yaml
+++ b/changelogs/fragments/214-add-disk-sharing.yaml
@@ -1,2 +1,0 @@
-minor_changes:
-  - vmware_guest_disk - add support for setting the sharing/multi-writer mode of virtual disks (https://github.com/ansible-collections/vmware/issues/212)

--- a/changelogs/fragments/219-vmware_content_deploy_template_added_param_content_library.yml
+++ b/changelogs/fragments/219-vmware_content_deploy_template_added_param_content_library.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - vmware_content_deploy_template - Added param content_library to the main function

--- a/changelogs/fragments/225-vmware_vcenter_settings.yml
+++ b/changelogs/fragments/225-vmware_vcenter_settings.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - vmware_vcenter_settings - Fixed when runtime_settings parameters not defined occur error(https://github.com/ansible/ansible/issues/66713)

--- a/changelogs/fragments/253-inventory_hostnames_fail_message.yml
+++ b/changelogs/fragments/253-inventory_hostnames_fail_message.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- vmware_vm_inventory inventory plugin, raise more descriptive error when all template strings in ``hostnames`` fail.

--- a/changelogs/fragments/33-vmware_guest_info_list_fix.yml
+++ b/changelogs/fragments/33-vmware_guest_info_list_fix.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- Handle list items in vSphere schema while handling facts using to_json API (https://github.com/ansible-collections/vmware/issues/33).

--- a/changelogs/fragments/44957-vmware_guest.yml
+++ b/changelogs/fragments/44957-vmware_guest.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - vmware_guest - add support VM creation and reconfiguration with multiple types of disk controllers and disks 

--- a/changelogs/fragments/46-Vcenter-infra-profile-config-operations.yml
+++ b/changelogs/fragments/46-Vcenter-infra-profile-config-operations.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- new code module for new feature for operations of VCenter infra profile config.

--- a/changelogs/fragments/55653-vmware_guest_powerstate.yml
+++ b/changelogs/fragments/55653-vmware_guest_powerstate.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- Add powerstates to match vmware_guest_powerstate module with vmware_guest (https://github.com/ansible/ansible/issues/55653).

--- a/changelogs/fragments/56-vmware_rest.yml
+++ b/changelogs/fragments/56-vmware_rest.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- Handle exceptions raised in connect_to_vsphere_client API.

--- a/changelogs/fragments/57185-fix_vmware_modules_py_pre2.79.yaml
+++ b/changelogs/fragments/57185-fix_vmware_modules_py_pre2.79.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-  - vmware - Ensure we can use the modules with Python < 2.7.9 or RHEL/CentOS < 7.4, this as soon as ``validate_certs`` is disabled.

--- a/changelogs/fragments/57535-vmware_vcenter_statistics_corner-cases.yml
+++ b/changelogs/fragments/57535-vmware_vcenter_statistics_corner-cases.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- vmware_vcenter_statistics - Fix some corner cases like increasing some interval and decreasing another at the same time.

--- a/changelogs/fragments/58-non-json-properties.yml
+++ b/changelogs/fragments/58-non-json-properties.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- In inventory plugin, serialize properties user specifies which are objects as dicts (https://github.com/ansible-collections/vmware/pull/58).

--- a/changelogs/fragments/58824-vmware_cluster_ha-advanced-settings.yml
+++ b/changelogs/fragments/58824-vmware_cluster_ha-advanced-settings.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- vmware_cluster_ha - Implemented HA advanced settings (https://github.com/ansible/ansible/issues/61421)

--- a/changelogs/fragments/58824-vmware_dvs_portgroup-implement-portgroup-updates.yml
+++ b/changelogs/fragments/58824-vmware_dvs_portgroup-implement-portgroup-updates.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- vmware_dvs_portgroup - Implemented configuration changes on an existing Distributed vSwitch portgroup.

--- a/changelogs/fragments/59_vmware_host_active_directory.yml
+++ b/changelogs/fragments/59_vmware_host_active_directory.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- vmware_host_active_directory - Fail when there are unrecoverable problems with AD membership instead of reporting a change that doesn't take place (https://github.com/ansible-collections/vmware/issues/59).

--- a/changelogs/fragments/62083-vmware-internal_results.yml
+++ b/changelogs/fragments/62083-vmware-internal_results.yml
@@ -1,6 +1,0 @@
-minor_changes:
-    - vmware_datastore_maintenancemode now returns datastore_status instead of Ansible internal key results (https://github.com/ansible/ansible/issues/62083).
-    - vmware_host_kernel_manager now returns host_kernel_status instead of Ansible internal key results (https://github.com/ansible/ansible/issues/62083).
-    - vmware_host_ntp now returns host_ntp_status instead of Ansible internal key results (https://github.com/ansible/ansible/issues/62083).
-    - vmware_host_service_manager now returns host_service_status instead of Ansible internal key results (https://github.com/ansible/ansible/issues/62083).
-    - vmware_tag now returns tag_status instead of Ansible internal key results (https://github.com/ansible/ansible/issues/62083).

--- a/changelogs/fragments/62188-VMware-Guest-Support-latest-version-while-upgrading-VM-hardware.yml
+++ b/changelogs/fragments/62188-VMware-Guest-Support-latest-version-while-upgrading-VM-hardware.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- vmware_guest - Add ability to upgrade the guest hardware version to latest fix issue (https://github.com/ansible/ansible/issues/56273).

--- a/changelogs/fragments/62616-vmware_cluster_ha-fix-documentation.yml
+++ b/changelogs/fragments/62616-vmware_cluster_ha-fix-documentation.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- vmware_cluster_ha - Remove a wrong parameter from an example in the documentation.

--- a/changelogs/fragments/62772-vmware_vmkernel_info-fix.yml
+++ b/changelogs/fragments/62772-vmware_vmkernel_info-fix.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- Check for virtualNicManager in Esxi host system before accessing properties in vmware_vmkernel_info (https://github.com/ansible/ansible/issues/62772).

--- a/changelogs/fragments/62810-Vmware-Guest-Allow-DashInWindowsServerDNSName.yml
+++ b/changelogs/fragments/62810-Vmware-Guest-Allow-DashInWindowsServerDNSName.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- vmware_guest - Allow '-' (Dash) special char in windows DNS name.

--- a/changelogs/fragments/62916-add_properties_option_to_vmware_host_facts.yml
+++ b/changelogs/fragments/62916-add_properties_option_to_vmware_host_facts.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - vmware_host_facts - added ``properties`` and ``schema`` options.

--- a/changelogs/fragments/629400-add_properties_option_to_vmware_datastore_info.yml
+++ b/changelogs/fragments/629400-add_properties_option_to_vmware_datastore_info.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - vmware_datastore_info - added ``properties`` and ``schema`` options.

--- a/changelogs/fragments/63740-vmware_guest_disk_filename_destroy.yaml
+++ b/changelogs/fragments/63740-vmware_guest_disk_filename_destroy.yaml
@@ -1,5 +1,0 @@
----
-
-minor_changes:
-  - vmware_guest_disk - Add `destroy` option which allows to remove a disk without deleting the VMDK file.
-  - vmware_guest_disk - Add `filename` option which allows to create a disk from an existing VMDK.

--- a/changelogs/fragments/63741-do_not_search_for_vmdk_if_filename_defined.yaml
+++ b/changelogs/fragments/63741-do_not_search_for_vmdk_if_filename_defined.yaml
@@ -1,4 +1,0 @@
----
-
-minor_changes:
-  - vmware_guest - Don't search for VMDK if filename is defined.

--- a/changelogs/fragments/64399_vmware_guest.yml
+++ b/changelogs/fragments/64399_vmware_guest.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- Handle slashes in VMware network name (https://github.com/ansible/ansible/issues/64399).

--- a/changelogs/fragments/64458-vmware_host_dns.yaml
+++ b/changelogs/fragments/64458-vmware_host_dns.yaml
@@ -1,4 +1,0 @@
-minor_changes:
-- vmware_host_dns - New module replacing vmware_dns_config with increased functionality.
-deprecated_features:
-- vmware_dns_config - Deprecate in favour of new module vmware_host_dns.

--- a/changelogs/fragments/65-vmware_guest.yml
+++ b/changelogs/fragments/65-vmware_guest.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - vmware_guest - add support for create and reconfigure CDROMs attaching to SATA (https://github.com/ansible/ansible/issues/42995)

--- a/changelogs/fragments/65154-vmware_datastore_cluster-configure-dns.yml
+++ b/changelogs/fragments/65154-vmware_datastore_cluster-configure-dns.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- vmware_datastore_cluster - Added basic SDRS configuration (https://github.com/ansible/ansible/issues/65154).

--- a/changelogs/fragments/65715-vmware-content-deploy-template-fix-cluster.yml
+++ b/changelogs/fragments/65715-vmware-content-deploy-template-fix-cluster.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- "`vmware_content_deploy_template`'s `cluster` argument no longer fails with an error message about resource pools."

--- a/changelogs/fragments/65733-fix-vmware-guest-properties-doc.yaml
+++ b/changelogs/fragments/65733-fix-vmware-guest-properties-doc.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-  - vmware_guest - Updated reference link to vapp_properties property

--- a/changelogs/fragments/65765-vmware_tag_manager.yml
+++ b/changelogs/fragments/65765-vmware_tag_manager.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- Added support to vmware_tag_manager module for specifying tag and category as dict if any of the name contains colon (https://github.com/ansible/ansible/issues/65765).

--- a/changelogs/fragments/65922-filter-VMs-of-Same-name-on-the-basis-of-folder.yml
+++ b/changelogs/fragments/65922-filter-VMs-of-Same-name-on-the-basis-of-folder.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - Vmware Fix for Create overwrites a VM of same name even when the folder is different(https://github.com/ansible/ansible/issues/43161)

--- a/changelogs/fragments/65968-vmware_guest_network.yml
+++ b/changelogs/fragments/65968-vmware_guest_network.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- In vmware_guest_network module use appropriate network while creating or reconfiguring (https://github.com/ansible/ansible/issues/65968).

--- a/changelogs/fragments/65997-vmware_guest-exclude-dvswitch-name-from-os-customization.yml
+++ b/changelogs/fragments/65997-vmware_guest-exclude-dvswitch-name-from-os-customization.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - vmware_guest - Exclude dvswitch_name from triggering guest os customization.

--- a/changelogs/fragments/66217-vmware_cluster_drs-advanced-settings.yml
+++ b/changelogs/fragments/66217-vmware_cluster_drs-advanced-settings.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- vmware_cluster_drs - Implemented DRS advanced settings (https://github.com/ansible/ansible/issues/66217)

--- a/changelogs/fragments/66340-vmware_tag.yml
+++ b/changelogs/fragments/66340-vmware_tag.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- Handle multiple tags name with different category id in vmware_tag module (https://github.com/ansible/ansible/issues/66340).

--- a/changelogs/fragments/66692-vmware_host_vmhba_info_fix_63045.yml
+++ b/changelogs/fragments/66692-vmware_host_vmhba_info_fix_63045.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - vmware_host_vmhba_info - fixed node_wwn and port_wwn for FC HBA to hexadecimal format(https://github.com/ansible/ansible/issues/63045).

--- a/changelogs/fragments/66877-vmware_host_dns.yaml
+++ b/changelogs/fragments/66877-vmware_host_dns.yaml
@@ -1,2 +1,0 @@
-minor_changes:
-  - vmware_host_dns can now set the following empty values, ``domain``, ``search_domains`` and ``dns_servers``. 

--- a/changelogs/fragments/66922-vmware_guest_network.yml
+++ b/changelogs/fragments/66922-vmware_guest_network.yml
@@ -1,5 +1,0 @@
----
-minor_changes:
-  - vmware_guest_network - put deprecation warning for the networks parameter
-  - vmware_guest_network - network adapters can be configured without lists
-  - vmware_guest_network - network_info returns a list of dictionaries for ease of use

--- a/changelogs/fragments/67221-vmware-guest-disk-storage-drs-fix.yml
+++ b/changelogs/fragments/67221-vmware-guest-disk-storage-drs-fix.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- return correct datastore cluster placement recommendations during when adding disk using the vmware_guest_disk module

--- a/changelogs/fragments/67282-remove_options_from_some_vmware_modules_that_aren't_used_in_the_code.yml
+++ b/changelogs/fragments/67282-remove_options_from_some_vmware_modules_that_aren't_used_in_the_code.yml
@@ -1,4 +1,0 @@
-removed_features:
-  - vmware_guest_find - Removed deprecated ``datacenter`` option
-  - vmware_vmkernel - Removed deprecated ``ip_address`` option; use sub-option ip_address in the network option instead
-  - vmware_vmkernel - Removed deprecated ``subnet_mask`` option; use sub-option subnet_mask in the network option instead

--- a/changelogs/fragments/67303-vmware_host_firewall_manager-fix_ip_specific_firewall_rules_for_python2.yml
+++ b/changelogs/fragments/67303-vmware_host_firewall_manager-fix_ip_specific_firewall_rules_for_python2.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- vmware_host_firewall_manager - Fixed creating IP specific firewall rules with Python 2 (https://github.com/ansible/ansible/issues/67303)

--- a/changelogs/fragments/67615-vmware_host_service_info_fix.yml
+++ b/changelogs/fragments/67615-vmware_host_service_info_fix.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- Handle NoneType error when accessing service system info in vmware_host_service_info module (https://github.com/ansible/ansible/issues/67615).

--- a/changelogs/fragments/69-vmware-extract-repeat-code.yaml
+++ b/changelogs/fragments/69-vmware-extract-repeat-code.yaml
@@ -1,2 +1,0 @@
-minor_changes:
-- vmware_guest - Extracts repeated code from configure_vapp_properties() to set_vapp_properties() in vmware_guest.py.

--- a/changelogs/fragments/7052_awx_handle_binary.yml
+++ b/changelogs/fragments/7052_awx_handle_binary.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- Handle Base64 Binary while JSON serialization in vmware_vm_inventory.

--- a/changelogs/fragments/75-vmware_guest_tool_upgrade.yml
+++ b/changelogs/fragments/75-vmware_guest_tool_upgrade.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- Add a flag 'force_upgrade' to force VMware tools upgrade installation (https://github.com/ansible-collections/vmware/issues/75).

--- a/changelogs/fragments/fix-vim-legacy-version-error-vmware_host_capability_facts.yml
+++ b/changelogs/fragments/fix-vim-legacy-version-error-vmware_host_capability_facts.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - vmware_host_capability_facts - Fixed vSphere API legacy version errors occur in pyvmomi 7.0 and later

--- a/changelogs/fragments/fix-vim-legacy-version-error-vmware_host_capability_info.yml
+++ b/changelogs/fragments/fix-vim-legacy-version-error-vmware_host_capability_info.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - vmware_host_capability_info - Fixed vSphere API legacy version errors occur in pyvmomi 7.0 and later

--- a/changelogs/fragments/metadata_removal.yml
+++ b/changelogs/fragments/metadata_removal.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- Removed ANSIBLE_METADATA from all the modules.

--- a/changelogs/fragments/typo_fix_vmware_guest_powerstate.yml
+++ b/changelogs/fragments/typo_fix_vmware_guest_powerstate.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- Fixed typo in vmware_guest_powerstate module (https://github.com/ansible/ansible/issues/65161).

--- a/changelogs/fragments/update_examples.yml
+++ b/changelogs/fragments/update_examples.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- Update Module examples with FQCN.

--- a/changelogs/fragments/vmware-module_fragments-group.yml
+++ b/changelogs/fragments/vmware-module_fragments-group.yml
@@ -1,4 +1,0 @@
----
-minor_changes:
-  - A `vmware` module_defaults group has been added to simplify parameters for
-    multiple VMware tasks. This group includes all VMware modules.

--- a/changelogs/fragments/vmware-only-add-configured-interfaces.yml
+++ b/changelogs/fragments/vmware-only-add-configured-interfaces.yml
@@ -1,2 +1,0 @@
-minor_changes:
-    - vmware.py - Only add configured network interfaces to facts.

--- a/changelogs/fragments/vmware_cluster_info_hosts.yml
+++ b/changelogs/fragments/vmware_cluster_info_hosts.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- Return additional information about hosts inside the cluster using vmware_cluster_info.

--- a/changelogs/fragments/vmware_content_deploy_ovf_template_add_storage_provision_type.yml
+++ b/changelogs/fragments/vmware_content_deploy_ovf_template_add_storage_provision_type.yml
@@ -1,2 +1,0 @@
-minor_changes:
-    - add storage_provisioning type into vmware_content_deploy_ovf_template.

--- a/changelogs/fragments/vmware_dvs_portgroup_info_key.yaml
+++ b/changelogs/fragments/vmware_dvs_portgroup_info_key.yaml
@@ -1,2 +1,0 @@
-minor_changes:
-- vmware_dvs_portgroup_info - Include the value of the Portgroup ``key`` in the result

--- a/changelogs/fragments/vmware_dvswitch_uuid.yaml
+++ b/changelogs/fragments/vmware_dvswitch_uuid.yaml
@@ -1,3 +1,0 @@
-minor_changes:
-  - vmware_dvswitch now returns the UUID of the switch
-  - vmware_dvswitch_info also returns the switch UUID

--- a/changelogs/fragments/vmware_export_ovf.yaml
+++ b/changelogs/fragments/vmware_export_ovf.yaml
@@ -1,4 +1,0 @@
----
-minor_changes:
-  - vmware_export_ovf - timeout value is actually in seconds, not minutes
-  - vmware_export_ovf - increase default timeout to 30s

--- a/changelogs/fragments/vmware_guest.yaml
+++ b/changelogs/fragments/vmware_guest.yaml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - Added a timeout parameter `wait_for_ip_address_timeout` for `wait_for_ip_address` for longer-running tasks in vmware_guest.

--- a/changelogs/fragments/vmware_guest_custom_attributes.yml
+++ b/changelogs/fragments/vmware_guest_custom_attributes.yml
@@ -1,2 +1,0 @@
-minor_changes:
-    - vmware_guest_custom_attributes does not require VM name (https://github.com/ansible/ansible/issues/63222).

--- a/changelogs/fragments/vmware_guest_disk_info_disk_mode.yml
+++ b/changelogs/fragments/vmware_guest_disk_info_disk_mode.yml
@@ -1,2 +1,0 @@
-minor_changes:
-    - Added missing backing_disk_mode information about disk which was removed by mistake in vmware_guest_disk_info.

--- a/changelogs/fragments/vmware_guest_tools_wait_time.yaml
+++ b/changelogs/fragments/vmware_guest_tools_wait_time.yaml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - vmware_guest_tools_wait now exposes a ``timeout`` parameter that allow the user to adjust the timeout (second).

--- a/changelogs/fragments/vmware_host_firewall_manager_fix_61332.yaml
+++ b/changelogs/fragments/vmware_host_firewall_manager_fix_61332.yaml
@@ -1,4 +1,0 @@
-bugfixes:
-- vmware_host_firewall_manager - Ensure we can set rule with no ``allowed_hosts`` key (https://github.com/ansible/ansible/issues/61332)
-minor_changes:
-- vmware_host_firewall_manager - ``allowed_hosts`` excpects a dict as parameter, list is deprecated

--- a/changelogs/fragments/vmware_host_lockdown_typo_fix.yml
+++ b/changelogs/fragments/vmware_host_lockdown_typo_fix.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- Correct datatype for state in vmware_host_lockdown module.

--- a/changelogs/fragments/vmware_httpapi_fix.yml
+++ b/changelogs/fragments/vmware_httpapi_fix.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- Minor typo fixes in vmware_httpapi related modules and module_utils.

--- a/changelogs/fragments/vmware_vm_inventory_compose.yml
+++ b/changelogs/fragments/vmware_vm_inventory_compose.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- Added 'compose' and 'groups' feature in vmware_vm_inventory plugin.

--- a/changelogs/fragments/vmware_vm_inventory_filter.yml
+++ b/changelogs/fragments/vmware_vm_inventory_filter.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- VMware guest inventory plugin support for filters.

--- a/changelogs/fragments/vmware_vm_inventory_keyed_groups.yml
+++ b/changelogs/fragments/vmware_vm_inventory_keyed_groups.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- Added keyed_groups feature in vmware_vm_inventory plugin.

--- a/changelogs/fragments/vmware_vm_inventory_port.yml
+++ b/changelogs/fragments/vmware_vm_inventory_port.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- vmware_vm_inventory inventory plugin, use the port value while connecting to vCenter (https://github.com/ansible/ansible/issues/64096).


### PR DESCRIPTION
The `1.0.0` release is done, we can now remove the changelog fragments.
