### PR TITLE
tests: remove shippable entries from aliases

### DIFF
--- a/tests/integration/targets/inventory_vmware_vm_inventory/aliases
+++ b/tests/integration/targets/inventory_vmware_vm_inventory/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/govcsim

--- a/tests/integration/targets/script_inventory_vmware_inventory/aliases
+++ b/tests/integration/targets/script_inventory_vmware_inventory/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group2
 cloud/vcenter
 destructive
 needs/file/contrib/inventory/vmware_inventory.py

--- a/tests/integration/targets/vcenter_extension_info/aliases
+++ b/tests/integration/targets/vcenter_extension_info/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 zuul/vmware/vcenter_only
 zuul/vmware/govcsim

--- a/tests/integration/targets/vcenter_folder/aliases
+++ b/tests/integration/targets/vcenter_folder/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 zuul/vmware/vcenter_only
 zuul/vmware/govcsim

--- a/tests/integration/targets/vcenter_license/aliases
+++ b/tests/integration/targets/vcenter_license/aliases
@@ -1,3 +1,2 @@
-shippable/vcenter/group1
 cloud/vcenter
 zuul/vmware/vcenter_only

--- a/tests/integration/targets/vmware_about_facts/aliases
+++ b/tests/integration/targets/vmware_about_facts/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only

--- a/tests/integration/targets/vmware_about_info/aliases
+++ b/tests/integration/targets/vmware_about_info/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only

--- a/tests/integration/targets/vmware_category/aliases
+++ b/tests/integration/targets/vmware_category/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only

--- a/tests/integration/targets/vmware_cluster/aliases
+++ b/tests/integration/targets/vmware_cluster/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only

--- a/tests/integration/targets/vmware_cluster_drs/aliases
+++ b/tests/integration/targets/vmware_cluster_drs/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only

--- a/tests/integration/targets/vmware_cluster_facts/aliases
+++ b/tests/integration/targets/vmware_cluster_facts/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_cluster_ha/aliases
+++ b/tests/integration/targets/vmware_cluster_ha/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only

--- a/tests/integration/targets/vmware_cluster_info/aliases
+++ b/tests/integration/targets/vmware_cluster_info/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_cluster_vsan/aliases
+++ b/tests/integration/targets/vmware_cluster_vsan/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only

--- a/tests/integration/targets/vmware_content_library_info/aliases
+++ b/tests/integration/targets/vmware_content_library_info/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_content_library_manager/aliases
+++ b/tests/integration/targets/vmware_content_library_manager/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_datacenter/aliases
+++ b/tests/integration/targets/vmware_datacenter/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only

--- a/tests/integration/targets/vmware_datacenter_info/aliases
+++ b/tests/integration/targets/vmware_datacenter_info/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only

--- a/tests/integration/targets/vmware_datastore_cluster/aliases
+++ b/tests/integration/targets/vmware_datastore_cluster/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only

--- a/tests/integration/targets/vmware_datastore_facts/aliases
+++ b/tests/integration/targets/vmware_datastore_facts/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_datastore_info/aliases
+++ b/tests/integration/targets/vmware_datastore_info/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_datastore_maintenancemode/aliases
+++ b/tests/integration/targets/vmware_datastore_maintenancemode/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_drs_group/aliases
+++ b/tests/integration/targets/vmware_drs_group/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_drs_group_facts/aliases
+++ b/tests/integration/targets/vmware_drs_group_facts/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only

--- a/tests/integration/targets/vmware_drs_group_info/aliases
+++ b/tests/integration/targets/vmware_drs_group_info/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only

--- a/tests/integration/targets/vmware_drs_rule_facts/aliases
+++ b/tests/integration/targets/vmware_drs_rule_facts/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_drs_rule_info/aliases
+++ b/tests/integration/targets/vmware_drs_rule_info/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_dvs_host/aliases
+++ b/tests/integration/targets/vmware_dvs_host/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_dvs_portgroup/aliases
+++ b/tests/integration/targets/vmware_dvs_portgroup/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only

--- a/tests/integration/targets/vmware_dvs_portgroup_facts/aliases
+++ b/tests/integration/targets/vmware_dvs_portgroup_facts/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only

--- a/tests/integration/targets/vmware_dvs_portgroup_find/aliases
+++ b/tests/integration/targets/vmware_dvs_portgroup_find/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_dvs_portgroup_info/aliases
+++ b/tests/integration/targets/vmware_dvs_portgroup_info/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_dvswitch/aliases
+++ b/tests/integration/targets/vmware_dvswitch/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only

--- a/tests/integration/targets/vmware_dvswitch_info/aliases
+++ b/tests/integration/targets/vmware_dvswitch_info/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only

--- a/tests/integration/targets/vmware_dvswitch_nioc/aliases
+++ b/tests/integration/targets/vmware_dvswitch_nioc/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_dvswitch_pvlans/aliases
+++ b/tests/integration/targets/vmware_dvswitch_pvlans/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_dvswitch_uplink_pg/aliases
+++ b/tests/integration/targets/vmware_dvswitch_uplink_pg/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_evc_mode/aliases
+++ b/tests/integration/targets/vmware_evc_mode/aliases
@@ -1,3 +1,2 @@
-shippable/vcenter/group1
 cloud/vcenter
 zuul/vmware/vcenter_only

--- a/tests/integration/targets/vmware_export_ovf/aliases
+++ b/tests/integration/targets/vmware_export_ovf/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_folder_info/aliases
+++ b/tests/integration/targets/vmware_folder_info/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only

--- a/tests/integration/targets/vmware_guest/aliases
+++ b/tests/integration/targets/vmware_guest/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_guest_boot_facts/aliases
+++ b/tests/integration/targets/vmware_guest_boot_facts/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_guest_boot_info/aliases
+++ b/tests/integration/targets/vmware_guest_boot_info/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_controller/aliases
+++ b/tests/integration/targets/vmware_guest_controller/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_custom_attribute_defs/aliases
+++ b/tests/integration/targets/vmware_guest_custom_attribute_defs/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_custom_attributes/aliases
+++ b/tests/integration/targets/vmware_guest_custom_attributes/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_customization_facts/aliases
+++ b/tests/integration/targets/vmware_guest_customization_facts/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_guest_customization_info/aliases
+++ b/tests/integration/targets/vmware_guest_customization_info/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_disk/aliases
+++ b/tests/integration/targets/vmware_guest_disk/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_disk_facts/aliases
+++ b/tests/integration/targets/vmware_guest_disk_facts/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi_with_nested

--- a/tests/integration/targets/vmware_guest_disk_info/aliases
+++ b/tests/integration/targets/vmware_guest_disk_info/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi_with_nested
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_facts/aliases
+++ b/tests/integration/targets/vmware_guest_facts/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_guest_find/aliases
+++ b/tests/integration/targets/vmware_guest_find/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_guest_info/aliases
+++ b/tests/integration/targets/vmware_guest_info/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_guest_move/aliases
+++ b/tests/integration/targets/vmware_guest_move/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_guest_network/aliases
+++ b/tests/integration/targets/vmware_guest_network/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi_with_nested
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_powerstate/aliases
+++ b/tests/integration/targets/vmware_guest_powerstate/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi_with_nested

--- a/tests/integration/targets/vmware_guest_register_operation/aliases
+++ b/tests/integration/targets/vmware_guest_register_operation/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_guest_screenshot/aliases
+++ b/tests/integration/targets/vmware_guest_screenshot/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi_with_nested
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_sendkey/aliases
+++ b/tests/integration/targets/vmware_guest_sendkey/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi_with_nest
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_serial_port/aliases
+++ b/tests/integration/targets/vmware_guest_serial_port/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_snapshot/aliases
+++ b/tests/integration/targets/vmware_guest_snapshot/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_snapshot_facts/aliases
+++ b/tests/integration/targets/vmware_guest_snapshot_facts/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_guest_snapshot_info/aliases
+++ b/tests/integration/targets/vmware_guest_snapshot_info/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_tools_info/aliases
+++ b/tests/integration/targets/vmware_guest_tools_info/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_tools_wait/aliases
+++ b/tests/integration/targets/vmware_guest_tools_wait/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi_with_nested

--- a/tests/integration/targets/vmware_host/aliases
+++ b/tests/integration/targets/vmware_host/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_2esxi

--- a/tests/integration/targets/vmware_host_acceptance/aliases
+++ b/tests/integration/targets/vmware_host_acceptance/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_host_active_directory/aliases
+++ b/tests/integration/targets/vmware_host_active_directory/aliases
@@ -1,3 +1,2 @@
 cloud/vcenter
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests

--- a/tests/integration/targets/vmware_host_auto_start/aliases
+++ b/tests/integration/targets/vmware_host_auto_start/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
 skip/python2.6
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_host_capability_facts/aliases
+++ b/tests/integration/targets/vmware_host_capability_facts/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_host_capability_info/aliases
+++ b/tests/integration/targets/vmware_host_capability_info/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_host_config_facts/aliases
+++ b/tests/integration/targets/vmware_host_config_facts/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_host_config_info/aliases
+++ b/tests/integration/targets/vmware_host_config_info/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group2
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_host_config_manager/aliases
+++ b/tests/integration/targets/vmware_host_config_manager/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_host_datastore/aliases
+++ b/tests/integration/targets/vmware_host_datastore/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_host_dns/aliases
+++ b/tests/integration/targets/vmware_host_dns/aliases
@@ -1,3 +1,2 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests

--- a/tests/integration/targets/vmware_host_dns_facts/aliases
+++ b/tests/integration/targets/vmware_host_dns_facts/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group2
 cloud/vcenter
 
 needs/target/prepare_vmware_tests

--- a/tests/integration/targets/vmware_host_dns_info/aliases
+++ b/tests/integration/targets/vmware_host_dns_info/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group2
 cloud/vcenter
 
 needs/target/prepare_vmware_tests

--- a/tests/integration/targets/vmware_host_facts/aliases
+++ b/tests/integration/targets/vmware_host_facts/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_host_feature_facts/aliases
+++ b/tests/integration/targets/vmware_host_feature_facts/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_host_feature_info/aliases
+++ b/tests/integration/targets/vmware_host_feature_info/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_host_firewall_facts/aliases
+++ b/tests/integration/targets/vmware_host_firewall_facts/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group2
 cloud/vcenter
 
 needs/target/prepare_vmware_tests

--- a/tests/integration/targets/vmware_host_firewall_info/aliases
+++ b/tests/integration/targets/vmware_host_firewall_info/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group2
 cloud/vcenter
 
 needs/target/prepare_vmware_tests

--- a/tests/integration/targets/vmware_host_firewall_manager/aliases
+++ b/tests/integration/targets/vmware_host_firewall_manager/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group2
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_2esxi

--- a/tests/integration/targets/vmware_host_hyperthreading/aliases
+++ b/tests/integration/targets/vmware_host_hyperthreading/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_host_ipv6/aliases
+++ b/tests/integration/targets/vmware_host_ipv6/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group2
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_host_iscsi/aliases
+++ b/tests/integration/targets/vmware_host_iscsi/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_host_kernel_manager/aliases
+++ b/tests/integration/targets/vmware_host_kernel_manager/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_host_logbundle/aliases
+++ b/tests/integration/targets/vmware_host_logbundle/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_host_logbundle_info/aliases
+++ b/tests/integration/targets/vmware_host_logbundle_info/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_host_ntp/aliases
+++ b/tests/integration/targets/vmware_host_ntp/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_host_ntp_facts/aliases
+++ b/tests/integration/targets/vmware_host_ntp_facts/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_host_ntp_info/aliases
+++ b/tests/integration/targets/vmware_host_ntp_info/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_host_package_facts/aliases
+++ b/tests/integration/targets/vmware_host_package_facts/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_host_package_info/aliases
+++ b/tests/integration/targets/vmware_host_package_info/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_host_powermgmt_policy/aliases
+++ b/tests/integration/targets/vmware_host_powermgmt_policy/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_host_powerstate/aliases
+++ b/tests/integration/targets/vmware_host_powerstate/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_host_scanhba/aliases
+++ b/tests/integration/targets/vmware_host_scanhba/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group2
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_host_service_facts/aliases
+++ b/tests/integration/targets/vmware_host_service_facts/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_host_service_info/aliases
+++ b/tests/integration/targets/vmware_host_service_info/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_host_service_manager/aliases
+++ b/tests/integration/targets/vmware_host_service_manager/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
 # see: https://github.com/ansible-collections/vmware/issues/101

--- a/tests/integration/targets/vmware_host_snmp/aliases
+++ b/tests/integration/targets/vmware_host_snmp/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_host_sriov/aliases
+++ b/tests/integration/targets/vmware_host_sriov/aliases
@@ -1,3 +1,2 @@
 cloud/vcenter
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests

--- a/tests/integration/targets/vmware_host_ssl_facts/aliases
+++ b/tests/integration/targets/vmware_host_ssl_facts/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group2
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_host_ssl_info/aliases
+++ b/tests/integration/targets/vmware_host_ssl_info/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group2
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_host_vmhba_facts/aliases
+++ b/tests/integration/targets/vmware_host_vmhba_facts/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_host_vmhba_info/aliases
+++ b/tests/integration/targets/vmware_host_vmhba_info/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_host_vmnic_facts/aliases
+++ b/tests/integration/targets/vmware_host_vmnic_facts/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_host_vmnic_info/aliases
+++ b/tests/integration/targets/vmware_host_vmnic_info/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_local_role_facts/aliases
+++ b/tests/integration/targets/vmware_local_role_facts/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group2
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_local_role_info/aliases
+++ b/tests/integration/targets/vmware_local_role_info/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group2
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_local_role_manager/aliases
+++ b/tests/integration/targets/vmware_local_role_manager/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group2
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only

--- a/tests/integration/targets/vmware_local_user_facts/aliases
+++ b/tests/integration/targets/vmware_local_user_facts/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_local_user_info/aliases
+++ b/tests/integration/targets/vmware_local_user_info/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_local_user_manager/aliases
+++ b/tests/integration/targets/vmware_local_user_manager/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_maintenancemode/aliases
+++ b/tests/integration/targets/vmware_maintenancemode/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group2
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_portgroup/aliases
+++ b/tests/integration/targets/vmware_portgroup/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_portgroup_facts/aliases
+++ b/tests/integration/targets/vmware_portgroup_facts/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group2
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_portgroup_info/aliases
+++ b/tests/integration/targets/vmware_portgroup_info/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group2
 cloud/vcenter
 
 needs/target/prepare_vmware_tests

--- a/tests/integration/targets/vmware_resource_pool/aliases
+++ b/tests/integration/targets/vmware_resource_pool/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group2
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_resource_pool_facts/aliases
+++ b/tests/integration/targets/vmware_resource_pool_facts/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group2
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only

--- a/tests/integration/targets/vmware_resource_pool_info/aliases
+++ b/tests/integration/targets/vmware_resource_pool_info/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group2
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only

--- a/tests/integration/targets/vmware_target_canonical_facts/aliases
+++ b/tests/integration/targets/vmware_target_canonical_facts/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_target_canonical_info/aliases
+++ b/tests/integration/targets/vmware_target_canonical_info/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_vc_infraprofile_info/aliases
+++ b/tests/integration/targets/vmware_vc_infraprofile_info/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_vcenter_statistics/aliases
+++ b/tests/integration/targets/vmware_vcenter_statistics/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group2
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only

--- a/tests/integration/targets/vmware_vm_facts/aliases
+++ b/tests/integration/targets/vmware_vm_facts/aliases
@@ -1,5 +1,3 @@
-shippable/vcenter/group2
-shippable/vcenter/smoketest
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_vm_host_drs_rule/aliases
+++ b/tests/integration/targets/vmware_vm_host_drs_rule/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_vm_info/aliases
+++ b/tests/integration/targets/vmware_vm_info/aliases
@@ -1,5 +1,3 @@
-shippable/vcenter/group2
-shippable/vcenter/smoketest
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_vm_inventory/aliases
+++ b/tests/integration/targets/vmware_vm_inventory/aliases
@@ -1,3 +1,2 @@
-shippable/vcenter/group1
 cloud/vcenter
 zuul/vmware/vcenter_1esxi_with_nested

--- a/tests/integration/targets/vmware_vm_storage_policy_info/aliases
+++ b/tests/integration/targets/vmware_vm_storage_policy_info/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group2
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_only

--- a/tests/integration/targets/vmware_vm_vm_drs_rule/aliases
+++ b/tests/integration/targets/vmware_vm_vm_drs_rule/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_vmkernel/aliases
+++ b/tests/integration/targets/vmware_vmkernel/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_vmkernel_facts/aliases
+++ b/tests/integration/targets/vmware_vmkernel_facts/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_vmkernel_info/aliases
+++ b/tests/integration/targets/vmware_vmkernel_info/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_vmotion/aliases
+++ b/tests/integration/targets/vmware_vmotion/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_2esxi

--- a/tests/integration/targets/vmware_vspan_session/aliases
+++ b/tests/integration/targets/vmware_vspan_session/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_vswitch/aliases
+++ b/tests/integration/targets/vmware_vswitch/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_2esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_vswitch_facts/aliases
+++ b/tests/integration/targets/vmware_vswitch_facts/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_vswitch_info/aliases
+++ b/tests/integration/targets/vmware_vswitch_info/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
-shippable/vcenter/group2
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim


### PR DESCRIPTION
We don't use when any-more, and the content is outdated.