### PR TITLE
Add the pyvmomi support version for VMware modules to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ collections:
 
 VMware community collection depends upon following third party libraries:
 
-* [`Pyvmomi`](https://github.com/vmware/pyvmomi)
+* [`Pyvmomi`](https://github.com/vmware/pyvmomi) >= 6.7.1.2018.12
 * [`vSphere Automation SDK for Python`](https://github.com/vmware/vsphere-automation-sdk-python/)
 
 ### Installing required libraries and SDK


### PR DESCRIPTION
##### SUMMARY

This PR is to add requirement the pyvmomi version to README.  
The VMware modules occurs an error of the `templateOf` if using pyvmomi 6.7.1 or less.

see: https://github.com/ansible-collections/vmware/issues/288

So, I think it is better to add pyvmomi support version to README.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

README.md

##### ADDITIONAL INFORMATION