### PR TITLE
vca_*: Deprecate vca

### DIFF
--- a/changelogs/fragments/vca_deprecate.yml
+++ b/changelogs/fragments/vca_deprecate.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+- vca - vca_fw, vca_nat, vca_app are deprecated since these modules rely on deprecated part of Pyvcloud library.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -135,6 +135,18 @@ action_groups:
 
 plugin_routing:
   modules:
+    vca_fw:
+      deprecation:
+        removal_date: 2022-06-01
+        warning_text: see plugin documentation for details
+    vca_nat:
+      deprecation:
+        removal_date: 2022-06-01
+        warning_text: see plugin documentation for details
+    vca_vapp:
+      deprecation:
+        removal_date: 2022-06-01
+        warning_text: see plugin documentation for details
     vcenter_extension_facts:
       deprecation:
         removal_date: 2021-12-01

--- a/plugins/modules/vca_fw.py
+++ b/plugins/modules/vca_fw.py
@@ -10,6 +10,10 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: vca_fw
+deprecated:
+  removed_at_date: '2022-06-01'
+  why: Module depends upon deprecated version of Pyvcloud library.
+  alternative: Use U(https://github.com/vmware/ansible-module-vcloud-director) instead.
 short_description: add remove firewall rules in a gateway  in a vca
 description:
   - Adds or removes firewall rules from a gateway in a vca environment
@@ -168,6 +172,11 @@ def main():
 
     module = AnsibleModule(argument_spec, supports_check_mode=True)
 
+    module.deprecate(
+        msg="The 'vca_fw' module is deprecated, Please use https://github.com/vmware/ansible-module-vcloud-director instead",
+        date="2022-06-01",
+        collection_name="community.vmware"
+    )
     fw_rules = module.params.get('fw_rules')
     gateway_name = module.params.get('gateway_name')
     vdc_name = module.params['vdc_name']

--- a/plugins/modules/vca_nat.py
+++ b/plugins/modules/vca_nat.py
@@ -10,6 +10,10 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: vca_nat
+deprecated:
+  removed_at_date: '2022-06-01'
+  why: Module depends upon deprecated version of Pyvcloud library.
+  alternative: Use U(https://github.com/vmware/ansible-module-vcloud-director) instead.
 short_description: add remove nat rules in a gateway  in a vca
 description:
   - Adds or removes nat rules from a gateway in a vca environment
@@ -128,7 +132,11 @@ def main():
     )
 
     module = AnsibleModule(argument_spec, supports_check_mode=True)
-
+    module.deprecate(
+        msg="The 'vca_nat' module is deprecated, Please use https://github.com/vmware/ansible-module-vcloud-director instead",
+        date="2022-06-01",
+        collection_name="community.vmware"
+    )
     vdc_name = module.params.get('vdc_name')
     nat_rules = module.params['nat_rules']
     gateway_name = module.params['gateway_name']

--- a/plugins/modules/vca_vapp.py
+++ b/plugins/modules/vca_vapp.py
@@ -9,6 +9,10 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: vca_vapp
+deprecated:
+  removed_at_date: '2022-06-01'
+  why: Module depends upon deprecated version of Pyvcloud library.
+  alternative: Use U(https://github.com/vmware/ansible-module-vcloud-director) instead.
 short_description: Manages vCloud Air vApp instances.
 description:
   - This module will actively managed vCloud Air vApp instances.  Instances
@@ -307,6 +311,12 @@ def main():
 
     module = VcaAnsibleModule(argument_spec=argument_spec,
                               supports_check_mode=True)
+
+    module.deprecate(
+        msg="The 'vca_fw' module is deprecated, Please use https://github.com/vmware/ansible-module-vcloud-director instead",
+        date="2022-06-01",
+        collection_name="community.vmware"
+    )
 
     state = module.params['state']
     operation = module.params['operation']

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -1,20 +1,20 @@
-plugins/modules/vca_fw.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/vca_fw.py validate-modules:doc-missing-type
-plugins/modules/vca_fw.py validate-modules:doc-required-mismatch
-plugins/modules/vca_fw.py validate-modules:parameter-list-no-elements
-plugins/modules/vca_fw.py validate-modules:parameter-type-not-in-doc
-plugins/modules/vca_fw.py validate-modules:undocumented-parameter
-plugins/modules/vca_nat.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/vca_nat.py validate-modules:doc-missing-type
-plugins/modules/vca_nat.py validate-modules:doc-required-mismatch
-plugins/modules/vca_nat.py validate-modules:parameter-list-no-elements
-plugins/modules/vca_nat.py validate-modules:parameter-type-not-in-doc
-plugins/modules/vca_nat.py validate-modules:undocumented-parameter
-plugins/modules/vca_vapp.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/vca_vapp.py validate-modules:doc-missing-type
-plugins/modules/vca_vapp.py validate-modules:doc-required-mismatch
-plugins/modules/vca_vapp.py validate-modules:invalid-ansiblemodule-schema
-plugins/modules/vca_vapp.py validate-modules:undocumented-parameter
+plugins/modules/vca_fw.py validate-modules:doc-default-does-not-match-spec # deprecated
+plugins/modules/vca_fw.py validate-modules:doc-missing-type # deprecated
+plugins/modules/vca_fw.py validate-modules:doc-required-mismatch # deprecated
+plugins/modules/vca_fw.py validate-modules:parameter-list-no-elements # deprecated
+plugins/modules/vca_fw.py validate-modules:parameter-type-not-in-doc # deprecated
+plugins/modules/vca_fw.py validate-modules:undocumented-parameter # deprecated
+plugins/modules/vca_nat.py validate-modules:doc-default-does-not-match-spec # deprecated
+plugins/modules/vca_nat.py validate-modules:doc-missing-type # deprecated
+plugins/modules/vca_nat.py validate-modules:doc-required-mismatch # deprecated
+plugins/modules/vca_nat.py validate-modules:parameter-list-no-elements # deprecated
+plugins/modules/vca_nat.py validate-modules:parameter-type-not-in-doc # deprecated
+plugins/modules/vca_nat.py validate-modules:undocumented-parameter # deprecated
+plugins/modules/vca_vapp.py validate-modules:doc-default-does-not-match-spec # deprecated
+plugins/modules/vca_vapp.py validate-modules:doc-missing-type # deprecated
+plugins/modules/vca_vapp.py validate-modules:doc-required-mismatch # deprecated
+plugins/modules/vca_vapp.py validate-modules:invalid-ansiblemodule-schema # deprecated
+plugins/modules/vca_vapp.py validate-modules:undocumented-parameter # deprecated
 plugins/modules/vcenter_extension_facts.py validate-modules:deprecation-mismatch
 plugins/modules/vcenter_extension_facts.py validate-modules:invalid-documentation
 plugins/modules/vcenter_extension_facts.py validate-modules:invalid-module-deprecation-version


### PR DESCRIPTION
##### SUMMARY

Deprecate vca_* since these modules are based upon
deprecated part of Pyvcloud library.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelogs/fragments/vca_deprecate.yml
meta/runtime.yml
plugins/modules/vca_fw.py
plugins/modules/vca_nat.py
plugins/modules/vca_vapp.py
tests/sanity/ignore-2.10.txt
