### PR TITLE
prefix fragment with module name

### DIFF
--- a/changelogs/fragments/52-vmware_dvs_portgroup_find_fix.yml
+++ b/changelogs/fragments/52-vmware_dvs_portgroup_find_fix.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- Fix comparison between str and int on method vlan_match (https://github.com/ansible-collections/vmware/pull/52).
+- vmware_dvs_portgroup_find - Fix comparison between str and int on method vlan_match (https://github.com/ansible-collections/vmware/pull/52).


### PR DESCRIPTION
Adjust the fragment of 5f13a14f7005633d2ad0f6988e501bf8951b6373 to
be sure it starts with the module name.