### PR TITLE
Fix connection plugin macro in BOTMETA

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -52,7 +52,7 @@ files:
     maintainers: $team_vmware
   $module_utils/vmware:
   $module_utils/vmware_httpapi:
-  $plugins/connection/vmware_tools.py:
+  $connection/vmware_tools.py:
     support: community
     maintainers: $team_vmware
     labels:
@@ -76,6 +76,7 @@ files:
 macros:
   action: plugins/action
   callback: plugins/callback
+  connection: plugins/connection
   doc_fragments: plugins/doc_fragments
   httpapi: plugins/httpapi
   inventory: plugins/inventory


### PR DESCRIPTION
##### SUMMARY
Fix connection plugin macro in BOTMETA

I didn't actually define a connection macro, and also used a bad macro for one of the connection plugins.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
.github/BOTMETA.yml

##### ADDITIONAL INFORMATION
Today I figured out how to test BOTMETA changes locally, so now I know this one actually works instead of just looking mostly right!  Issue 272 will likely need a bot_skip, the bot breaks on that one (in dry-run) and I haven't dug into why yet (maybe needs template?).
