### PR TITLE
vmware_cluster_ha: Truthy strings as strings instead of booleans

### DIFF
--- a/changelogs/fragments/286-vmware_cluster_ha.yml
+++ b/changelogs/fragments/286-vmware_cluster_ha.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_cluster_ha - treat truthy advanced options ('true', 'false') as strings instead of booleans (https://github.com/ansible-collections/vmware/issues/286).

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -855,14 +855,16 @@ def is_truthy(value):
 
 # options is the dict as defined in the module parameters, current_options is
 # the list of the currently set options as returned by the vSphere API.
-def option_diff(options, current_options):
+# When truthy_strings_as_bool is True, strings like 'true', 'off' or 'yes'
+# are converted to booleans.
+def option_diff(options, current_options, truthy_strings_as_bool=True):
     current_options_dict = {}
     for option in current_options:
         current_options_dict[option.key] = option.value
 
     change_option_list = []
     for option_key, option_value in options.items():
-        if is_boolean(option_value):
+        if truthy_strings_as_bool and is_boolean(option_value):
             option_value = VmomiSupport.vmodlTypes['bool'](is_truthy(option_value))
         elif isinstance(option_value, int):
             option_value = VmomiSupport.vmodlTypes['int'](option_value)

--- a/plugins/modules/vmware_cluster_ha.py
+++ b/plugins/modules/vmware_cluster_ha.py
@@ -266,7 +266,7 @@ class VMwareCluster(PyVmomi):
 
         self.advanced_settings = self.params.get('advanced_settings')
         if self.advanced_settings:
-            self.changed_advanced_settings = option_diff(self.advanced_settings, self.cluster.configurationEx.dasConfig.option)
+            self.changed_advanced_settings = option_diff(self.advanced_settings, self.cluster.configurationEx.dasConfig.option, False)
         else:
             self.changed_advanced_settings = None
 

--- a/tests/integration/targets/vmware_cluster_ha/tasks/main.yml
+++ b/tests/integration/targets/vmware_cluster_ha/tasks/main.yml
@@ -162,6 +162,39 @@
       that:
         - not change_num_heartbeat_ds_again.changed
 
+  - name: Change advanced setting "das.includeFTcomplianceChecks" (check-mode)
+    vmware_cluster_ha: &change_includeFTcomplianceChecks
+      validate_certs: False
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      datacenter_name: "{{ dc1 }}"
+      cluster_name: test_cluster_ha
+      advanced_settings:
+          'das.includeFTcomplianceChecks': 'false'
+    check_mode: yes
+    register: change_includeFTcomplianceChecks_check
+
+  - assert:
+      that:
+        - change_includeFTcomplianceChecks_check.changed
+
+  - name: Change advanced setting "das.includeFTcomplianceChecks"
+    vmware_cluster_ha: *change_includeFTcomplianceChecks
+    register: change_includeFTcomplianceChecks
+
+  - assert:
+      that:
+        - change_includeFTcomplianceChecks.changed
+
+  - name: Change advanced setting "das.includeFTcomplianceChecks" again
+    vmware_cluster_ha: *change_includeFTcomplianceChecks
+    register: change_includeFTcomplianceChecks_again
+
+  - assert:
+      that:
+        - not change_includeFTcomplianceChecks_again.changed
+
   # Delete test cluster
   - name: Delete test cluster
     vmware_cluster:

--- a/tests/integration/targets/vmware_host_config_manager/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_config_manager/tasks/main.yml
@@ -88,3 +88,39 @@
     assert:
       that:
           - all_hosts_result_check_mode.changed
+
+  # Test that PR 332 doesn't break boolean settings for this module.
+  - name: Change a boolean setting for a given host (check-mode)
+    vmware_host_config_manager: &change_logDirUnique
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      esxi_hostname: '{{ esxi1 }}'
+      options:
+        'Syslog.global.logDirUnique': true
+      validate_certs: no
+    check_mode: yes
+    register: change_logDirUnique_check
+
+  - name: ensure changes would be done to given host
+    assert:
+      that:
+          - change_logDirUnique_check.changed
+
+  - name: Change a boolean setting for a given host
+    vmware_host_config_manager: *change_logDirUnique
+    register: change_logDirUnique
+
+  - name: ensure changes are done to given host
+    assert:
+      that:
+          - change_logDirUnique.changed
+
+  - name: Change a boolean setting for a given host again
+    vmware_host_config_manager: *change_logDirUnique
+    register: change_logDirUnique_again
+
+  - name: ensure changes are not done to given host
+    assert:
+      that:
+          - not change_logDirUnique_again.changed


### PR DESCRIPTION
##### SUMMARY
At the moment, advanced HA options that are truthy like `true` or `off` are treated as booleans although the vSphere API expects strings.

Fixes #286 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_cluster_ha

