### PR TITLE
vmware_content_deploy_ovf_template - requires the resource_pool param

### DIFF
--- a/changelogs/fragments/163-vmware_content_deploy_ovf_template.py.yml
+++ b/changelogs/fragments/163-vmware_content_deploy_ovf_template.py.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_content_deploy_ovf_template - requires the resource_pool parameter.

--- a/plugins/modules/vmware_content_deploy_ovf_template.py
+++ b/plugins/modules/vmware_content_deploy_ovf_template.py
@@ -52,14 +52,14 @@ options:
       required: True
     host:
       description:
-      - Name of the ESX Host in datacenter in which to place deployed VM.
+      - Name of the ESX Host in datacenter in which to place deployed VM. The host has to be a member of the cluster that contains the resource pool.
       type: str
       required: True
     resource_pool:
       description:
       - Name of the resourcepool in datacenter in which to place deployed VM.
       type: str
-      required: False
+      required: True
     cluster:
       description:
       - Name of the cluster in datacenter in which to place deployed VM.
@@ -165,11 +165,9 @@ class VmwareContentDeployOvfTemplate(VmwareRestClient):
         if not self.host_id:
             self.module.fail_json(msg="Failed to find the Host %s" % self.host)
         # Find the resourcepool by the given resourcepool name
-        self.resourcepool_id = None
-        if self.resourcepool:
-            self.resourcepool_id = self.get_resource_pool_by_name(self.datacenter, self.resourcepool)
-            if not self.resourcepool_id:
-                self.module.fail_json(msg="Failed to find the resource_pool %s" % self.resourcepool)
+        self.resourcepool_id = self.get_resource_pool_by_name(self.datacenter, self.resourcepool)
+        if not self.resourcepool_id:
+            self.module.fail_json(msg="Failed to find the resource_pool %s" % self.resourcepool)
         # Find the Cluster by the given Cluster name
         self.cluster_id = None
         if self.cluster:
@@ -230,7 +228,7 @@ def main():
         datastore=dict(type='str', required=True),
         folder=dict(type='str', required=True),
         host=dict(type='str', required=True),
-        resource_pool=dict(type='str', required=False),
+        resource_pool=dict(type='str', required=True),
         cluster=dict(type='str', required=False),
         storage_provisioning=dict(type='str',
                                   required=False,


### PR DESCRIPTION


##### SUMMARY
Fixes #163 vmware_content_deploy_ovf_template - requires the resource_pool param

<!--- HINT: Include "" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_content_deploy_ovf_template 

##### ADDITIONAL INFORMATION
There is the issue https://github.com/ansible-collections/vmware/issues/163 that vmware_content_deploy_ovf_template  doesn't work without specified resource pool. However, According the vmware [documentation](https://vdc-repo.vmware.com/vmwb-repository/dcr-public/1cd28284-3b72-4885-9e31-d1c6d9e26686/71ef7304-a6c9-43b3-a3cd-868b2c236c81/doc/operations/com/vmware/vcenter/ovf/library_item.deploy-operation.html) it has to be specified


```
identifier of the resource pool to which the virtual machine or virtual appliance should be attached.
When clients pass a value of this structure as a parameter, the field must be an identifier for the resource type: ResourcePool. When operations return a value of this structure as a result, the field will be an identifier for the resource type: ResourcePool.
```
