### PR TITLE
fixed issue where wrong resource pool identifier was returned

### DIFF
--- a/changelogs/fragments/363-vmware_content_deploy_ovf_template.yml
+++ b/changelogs/fragments/363-vmware_content_deploy_ovf_template.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_content_deploy_ovf_template - fixed issue where wrong resource pool identifier was returned when same resource pool name was used across clusters in the same datacenter (https://github.com/ansible-collections/vmware/pull/363)

--- a/changelogs/fragments/363-vmware_content_deploy_ovf_template.yml
+++ b/changelogs/fragments/363-vmware_content_deploy_ovf_template.yml
@@ -1,2 +1,3 @@
 bugfixes:
   - vmware_content_deploy_ovf_template - fixed issue where wrong resource pool identifier was returned when same resource pool name was used across clusters in the same datacenter (https://github.com/ansible-collections/vmware/pull/363)
+

--- a/plugins/module_utils/vmware_rest_client.py
+++ b/plugins/module_utils/vmware_rest_client.py
@@ -340,7 +340,7 @@ class VmwareRestClient(object):
         folder = folder_summaries[0].folder if len(folder_summaries) > 0 else None
         return folder
 
-    def get_resource_pool_by_name(self, datacenter_name, resourcepool_name):
+    def get_resource_pool_by_name(self, datacenter_name, resourcepool_name, cluster_name=None, host_name=None):
         """
         Returns the identifier of a resource pool
         with the mentioned names.
@@ -348,9 +348,20 @@ class VmwareRestClient(object):
         datacenter = self.get_datacenter_by_name(datacenter_name)
         if not datacenter:
             return None
+        clusters = None
+        if cluster_name:
+            clusters = self.get_cluster_by_name(datacenter_name, cluster_name)
+            if clusters:
+                clusters = set([clusters])
+        hosts = None
+        if host_name:
+            hosts = self.get_host_by_name(datacenter_name, host_name)
+            if hosts:
+                hosts = set([hosts])
         names = set([resourcepool_name]) if resourcepool_name else None
         filter_spec = ResourcePool.FilterSpec(datacenters=set([datacenter]),
-                                              names=names)
+                                              names=names,
+                                              clusters=clusters)
         resource_pool_summaries = self.api_client.vcenter.ResourcePool.list(filter_spec)
         resource_pool = resource_pool_summaries[0].resource_pool if len(resource_pool_summaries) > 0 else None
         return resource_pool

--- a/plugins/modules/vmware_content_deploy_ovf_template.py
+++ b/plugins/modules/vmware_content_deploy_ovf_template.py
@@ -165,7 +165,7 @@ class VmwareContentDeployOvfTemplate(VmwareRestClient):
         if not self.host_id:
             self.module.fail_json(msg="Failed to find the Host %s" % self.host)
         # Find the resourcepool by the given resourcepool name
-        self.resourcepool_id = self.get_resource_pool_by_name(self.datacenter, self.resourcepool)
+        self.resourcepool_id = self.get_resource_pool_by_name(self.datacenter, self.resourcepool, self.cluster, self.host)
         if not self.resourcepool_id:
             self.module.fail_json(msg="Failed to find the resource_pool %s" % self.resourcepool)
         # Find the Cluster by the given Cluster name


### PR DESCRIPTION

##### SUMMARY
Fixed issue where the wrong resource identifier was returned in environments where the same resource pool name exists across multiple clusters in a data center

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_content_deploy_ovf_template
vmware_rest_client
##### ADDITIONAL INFORMATION
The get_resource_pool_by_name doesn't include cluster or host in the filter spec and as a result will always return the identifier of the first resource pool with the same name
