### PR TITLE
Fix Repl and Repl_NFC detection

### DIFF
--- a/changelogs/fragments/364-vmware_vmkernel-replciation-fix.yml
+++ b/changelogs/fragments/364-vmware_vmkernel-replciation-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_vmkernel - fixed issue were Repl and ReplNFC services were not being identified as enabled on a vmk interface (https://github.com/ansible-collections/vmware/issues/362).

--- a/changelogs/fragments/364-vmware_vmkernel-replciation-fix.yml
+++ b/changelogs/fragments/364-vmware_vmkernel-replciation-fix.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - vmware_vmkernel - fixed issue were Repl and ReplNFC services were not being identified as enabled on a vmk interface (https://github.com/ansible-collections/vmware/issues/362).
+  - vmware_vmkernel - fixed issue where Repl and ReplNFC services were not being identified as enabled on a vmk interface (https://github.com/ansible-collections/vmware/issues/362).

--- a/plugins/modules/vmware_vmkernel.py
+++ b/plugins/modules/vmware_vmkernel.py
@@ -614,11 +614,11 @@ class PyVmomiHelper(PyVmomi):
                 changed_services = changed_service_prov = True
 
             if (self.enable_replication and self.vnic.device not in service_type_vmks['vSphereReplication']) or \
-                    (not self.enable_provisioning and self.vnic.device in service_type_vmks['vSphereReplication']):
+                    (not self.enable_replication and self.vnic.device in service_type_vmks['vSphereReplication']):
                 changed_services = changed_service_rep = True
 
             if (self.enable_replication_nfc and self.vnic.device not in service_type_vmks['vSphereReplicationNFC']) or \
-                    (not self.enable_provisioning and self.vnic.device in service_type_vmks['vSphereReplicationNFC']):
+                    (not self.enable_replication_nfc and self.vnic.device in service_type_vmks['vSphereReplicationNFC']):
                 changed_services = changed_service_rep_nfc = True
             if changed_services:
                 changed_list.append("services")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #362 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Module: vmware_vmkernel
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Logic to detect if Replication and Replication NFC are enabled on a VMK is not idempotent. The code checks for provisioning service instead of replication and replication NFC.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
