### PR TITLE
Fix issue of the vmware_cluster_info module does not decode of a clus…

### DIFF
--- a/changelogs/fragments/366-vmware_cluster_info.yml
+++ b/changelogs/fragments/366-vmware_cluster_info.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_cluster_info - Fixed issue of a cluster name doesn't URL-decode(https://github.com/ansible-collections/vmware/pull/366)

--- a/plugins/modules/vmware_cluster_info.py
+++ b/plugins/modules/vmware_cluster_info.py
@@ -187,6 +187,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six.moves.urllib.parse import unquote
 from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec, find_datacenter_by_name, find_cluster_by_name
 from ansible_collections.community.vmware.plugins.module_utils.vmware_rest_client import VmwareRestClient
 
@@ -290,7 +291,7 @@ class VmwreClusterInfoManager(PyVmomi):
                 if '_vimtype' in resource_summary:
                     del resource_summary['_vimtype']
 
-                results['clusters'][cluster.name] = dict(
+                results['clusters'][unquote(cluster.name)] = dict(
                     hosts=hosts,
                     enable_ha=das_config.enabled,
                     ha_failover_level=ha_failover_level,
@@ -314,7 +315,7 @@ class VmwreClusterInfoManager(PyVmomi):
                 )
         else:
             for cluster in self.cluster_objs:
-                results['clusters'][cluster.name] = self.to_json(cluster, self.properties)
+                results['clusters'][unquote(cluster.name)] = self.to_json(cluster, self.properties)
 
         self.module.exit_json(**results)
 

--- a/tests/integration/targets/vmware_cluster_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_cluster_info/tasks/main.yml
@@ -138,3 +138,33 @@
 #      that:
 #        - cluster_info is defined
 #        - cluster_info.clusters[ccr1].tags is defined
+
+- name: "Prepare a cluster name with character to be URL-encoded"
+  vmware_cluster:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
+    datacenter_name: "{{ dc1 }}"
+    cluster_name: 'Cluster/\%'
+    state: present
+  register: prepare_cluster_url_encoded_result
+
+- assert:
+    that:
+      - prepare_cluster_url_encoded_result.changed is sameas true
+
+- name: "Gather information about all datacenter"
+  vmware_cluster_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
+    datacenter: "{{ dc1 }}"
+  register: all_cluster_result
+
+- name: "Ensure URL-encoded cluster name"
+  assert:
+    that:
+      - all_cluster_result.clusters['Cluster/\%']
+


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/vmware/pull/374

##### SUMMARY

This PR is to fix the vmware_cluster_info module does not urldecode of a cluster name.  
fixes: https://github.com/ansible-collections/vmware/issues/365

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/modules/vmware_cluster_info

##### ADDITIONAL INFORMATION

tested on vCenter/ESXi 6.7
