### PR TITLE
Fix to split the variables setting process by determining whether it …

### DIFF
--- a/changelogs/fragments/368-vmware_guest_customization_info.yml
+++ b/changelogs/fragments/368-vmware_guest_customization_info.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_guest_customization_info - Fixed to get values properly for LinuxPrep and SysPrep parameters(https://github.com/ansible-collections/vmware/pull/368)

--- a/plugins/modules/vmware_guest_customization_info.py
+++ b/plugins/modules/vmware_guest_customization_info.py
@@ -130,7 +130,7 @@ class VmwareCustomSpecManger(PyVmomi):
             for nic in current_spec.spec.nicSettingMap:
                 temp_data = dict(
                     mac_address=nic.macAddress,
-                    ip_address=nic.adapter.ip.ipAddress if hasattr(nic.adapter.ip, 'ipAddress') else '',
+                    ip_address=nic.adapter.ip.ipAddress if hasattr(nic.adapter.ip, 'ipAddress') else None,
                     subnet_mask=nic.adapter.subnetMask,
                     gateway=list(nic.adapter.gateway),
                     nic_dns_server_list=list(nic.adapter.dnsServerList),


### PR DESCRIPTION
##### SUMMARY

This PR is to fix the variables setting process by determining whether it is LinuxPrep or SysPrep in the vmware_guest_customization_info module.  
And fix the ip_address variable default value is to set None if it has not an attribute.

fixes: https://github.com/ansible-collections/vmware/issues/360

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/modules/vmware_guest_customization_info

##### ADDITIONAL INFORMATION

tested on vCenter7.0
