### PR TITLE
pylint: ensure the check pass

### DIFF
--- a/plugins/inventory/vmware_vm_inventory.py
+++ b/plugins/inventory/vmware_vm_inventory.py
@@ -404,7 +404,7 @@ class BaseVMwareInventory:
             raise AnsibleError("Missing one of the following : hostname, username, password. Please read "
                                "the documentation for more information.")
 
-    def get_managed_objects_properties(self, vim_type, properties=None, resources=None, strict=False):
+    def get_managed_objects_properties(self, vim_type, properties=None, resources=None, strict=False):  # noqa  # pylint: disable=too-complex
         """
         Look up a Managed Object Reference in vCenter / ESXi Environment
         :param vim_type: Type of vim object e.g, for datacenter - vim.Datacenter

--- a/scripts/inventory/vmware.py
+++ b/scripts/inventory/vmware.py
@@ -306,7 +306,7 @@ class VMwareInventory(object):
                 group_children.append(child_group)
         inv.setdefault(child_group, [])
 
-    def get_inventory(self, meta_hostvars=True):
+    def get_inventory(self, meta_hostvars=True):  # noqa  # pylint: disable=too-complex
         '''
         Reads the inventory from cache or VMware API via pSphere.
         '''

--- a/scripts/inventory/vmware_inventory.py
+++ b/scripts/inventory/vmware_inventory.py
@@ -349,7 +349,7 @@ class VMWareInventory(object):
         if self.validate_certs and hasattr(ssl, 'SSLContext'):
             context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
             context.verify_mode = ssl.CERT_REQUIRED
-            context.check_hostname = True
+            context.check_hostname = True  # noqa  # pylint: disable=assigning-non-slot
             kwargs['sslContext'] = context
         elif self.validate_certs and not hasattr(ssl, 'SSLContext'):
             sys.exit('pyVim does not support changing verification mode with python < 2.7.9. Either update '
@@ -357,7 +357,7 @@ class VMWareInventory(object):
         elif not self.validate_certs and hasattr(ssl, 'SSLContext'):
             context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
             context.verify_mode = ssl.CERT_NONE
-            context.check_hostname = False
+            context.check_hostname = False  # noqa  # pylint: disable=assigning-non-slot
             kwargs['sslContext'] = context
         elif not self.validate_certs and not hasattr(ssl, 'SSLContext'):
             # Python 2.7.9 < or RHEL/CentOS 7.4 <
@@ -428,7 +428,7 @@ class VMWareInventory(object):
 
         return instance_tuples
 
-    def instances_to_inventory(self, instances):
+    def instances_to_inventory(self, instances):  # noqa  # pylint: disable=too-complex
         ''' Convert a list of vm objects into a json compliant inventory '''
         self.debugl('re-indexing instances based on ini settings')
         inventory = VMWareInventory._empty_inventory()
@@ -564,7 +564,7 @@ class VMWareInventory(object):
             mapping[k] = newkey
         return mapping
 
-    def facts_from_proplist(self, vm):
+    def facts_from_proplist(self, vm):  # noqa  # pylint: disable=too-complex
         '''Get specific properties instead of serializing everything'''
 
         rdata = {}
@@ -687,7 +687,7 @@ class VMWareInventory(object):
 
         return rdata
 
-    def _process_object_types(self, vobj, thisvm=None, inkey='', level=0):
+    def _process_object_types(self, vobj, thisvm=None, inkey='', level=0):  # noqa  # pylint: disable=too-complex
         ''' Serialize an object '''
         rdata = {}
 


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/635

We ignore some `too-complex` errors. Most of them are in legacy inventory
scripts, so it's not really important.
One remains in scripts/inventory/vmware.py, but the code is rather clear
and complexity is not that high.