### PR TITLE
vmware_cluster: Don't ignore vim.fault.DuplicateName exception

### DIFF
--- a/plugins/modules/vmware_cluster.py
+++ b/plugins/modules/vmware_cluster.py
@@ -411,9 +411,6 @@ class VMwareCluster(PyVmomi):
             if not self.module.check_mode:
                 self.datacenter.hostFolder.CreateClusterEx(self.cluster_name, cluster_config_spec)
             self.module.exit_json(changed=True)
-        except vim.fault.DuplicateName:
-            # To match other vmware_* modules
-            pass
         except vmodl.fault.InvalidArgument as invalid_args:
             self.module.fail_json(msg="Cluster configuration specification"
                                       " parameter is invalid : %s" % to_native(invalid_args.msg))


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/vmware/pull/374

##### SUMMARY
vmware_cluster ignores an exception (vim.fault.DuplicateName) which is never a good idea:

https://github.com/ansible-collections/vmware/blob/aee551dc1d1f8a57f58f2da47bef7678b2461973/plugins/modules/vmware_cluster.py#L414-L416

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_cluster

##### ADDITIONAL INFORMATION
Fixes #375 