### PR TITLE
Support special characters in an object name

### DIFF
--- a/changelogs/fragments/380-vmware-handle-special-characters.yml
+++ b/changelogs/fragments/380-vmware-handle-special-characters.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - ``module_utils/vmware.py`` handle an object name using special characters that URL-decoded(https://github.com/ansible-collections/vmware/pull/380).
+  - "``module_utils/vmware.py`` handles an object name using special characters that URL-decoded(https://github.com/ansible-collections/vmware/pull/380)."

--- a/changelogs/fragments/380-vmware-handle-special-characters.yml
+++ b/changelogs/fragments/380-vmware-handle-special-characters.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ``module_utils/vmware.py`` handle an object name using special characters that URL-decoded(https://github.com/ansible-collections/vmware/pull/380).

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -42,6 +42,7 @@ except ImportError:
 from ansible.module_utils._text import to_text, to_native
 from ansible.module_utils.six import integer_types, iteritems, string_types, raise_from
 from ansible.module_utils.basic import env_fallback, missing_required_lib
+from ansible.module_utils.six.moves.urllib.parse import unquote
 
 
 class TaskError(Exception):
@@ -132,7 +133,7 @@ def find_object_by_name(content, name, obj_type, folder=None, recurse=True):
 
     objects = get_all_objs(content, obj_type, folder=folder, recurse=recurse)
     for obj in objects:
-        if obj.name == name:
+        if unquote(obj.name) == name:
             return obj
 
     return None
@@ -1010,7 +1011,7 @@ class PyVmomi(object):
             for temp_vm_object in objects:
                 if (
                     len(temp_vm_object.propSet) == 1
-                    and temp_vm_object.propSet[0].val == self.params["name"]
+                    and unquote(temp_vm_object.propSet[0].val) == self.params["name"]
                 ):
                     vms.append(temp_vm_object.obj)
 

--- a/tests/integration/targets/vmware_cluster/tasks/main.yml
+++ b/tests/integration/targets/vmware_cluster/tasks/main.yml
@@ -61,62 +61,62 @@
       that:
           - "{{ cluster_result_0001.changed == false }}"
 
-- name: Create Cluster with special characters
-  vmware_cluster:
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    validate_certs: false
-    datacenter_name: "{{ dc1 }}"
-    cluster_name: 'Cluster\/%'
-    state: present
-  register: create_cluster_with_special_characters_result
+  - name: Create Cluster with special characters
+    vmware_cluster:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      validate_certs: false
+      datacenter_name: "{{ dc1 }}"
+      cluster_name: 'Cluster\/%'
+      state: present
+    register: create_cluster_with_special_characters_result
 
-- assert:
-    that:
-      - create_cluster_with_special_characters_result.changed is sameas true
+  - assert:
+      that:
+        - create_cluster_with_special_characters_result.changed is sameas true
 
-- name: Create Cluster with special characters(idempotency check)
-  vmware_cluster:
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    validate_certs: false
-    datacenter_name: "{{ dc1 }}"
-    cluster_name: 'Cluster\/%'
-    state: present
-  register: create_cluster_with_special_characters_idempotency_check_result
+  - name: Create Cluster with special characters(idempotency check)
+    vmware_cluster:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      validate_certs: false
+      datacenter_name: "{{ dc1 }}"
+      cluster_name: 'Cluster\/%'
+      state: present
+    register: create_cluster_with_special_characters_idempotency_check_result
 
-- assert:
-    that:
-      - create_cluster_with_special_characters_idempotency_check_result.changed is sameas false
+  - assert:
+      that:
+        - create_cluster_with_special_characters_idempotency_check_result.changed is sameas false
 
-- name: Delete Cluster with special characters
-  vmware_cluster:
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    validate_certs: false
-    datacenter_name: "{{ dc1 }}"
-    cluster_name: 'Cluster\/%'
-    state: absent
-  register: delete_cluster_with_special_characters_result
+  - name: Delete Cluster with special characters
+    vmware_cluster:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      validate_certs: false
+      datacenter_name: "{{ dc1 }}"
+      cluster_name: 'Cluster\/%'
+      state: absent
+    register: delete_cluster_with_special_characters_result
 
-- assert:
-    that:
-      - delete_cluster_with_special_characters_result.changed is sameas true
+  - assert:
+      that:
+        - delete_cluster_with_special_characters_result.changed is sameas true
 
-- name: Delete Cluster with special characters(idempotency check)
-  vmware_cluster:
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    validate_certs: false
-    datacenter_name: "{{ dc1 }}"
-    cluster_name: 'Cluster\/%'
-    state: absent
-  register: delete_cluster_with_special_characters_idempotency_check_result
+  - name: Delete Cluster with special characters(idempotency check)
+    vmware_cluster:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      validate_certs: false
+      datacenter_name: "{{ dc1 }}"
+      cluster_name: 'Cluster\/%'
+      state: absent
+    register: delete_cluster_with_special_characters_idempotency_check_result
 
-- assert:
-    that:
-      - delete_cluster_with_special_characters_idempotency_check_result.changed is sameas false
+  - assert:
+      that:
+        - delete_cluster_with_special_characters_idempotency_check_result.changed is sameas false

--- a/tests/integration/targets/vmware_cluster/tasks/main.yml
+++ b/tests/integration/targets/vmware_cluster/tasks/main.yml
@@ -60,3 +60,63 @@
     assert:
       that:
           - "{{ cluster_result_0001.changed == false }}"
+
+- name: Create Cluster with special characters
+  vmware_cluster:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    datacenter_name: "{{ dc1 }}"
+    cluster_name: 'Cluster\/%'
+    state: present
+  register: create_cluster_with_special_characters_result
+
+- assert:
+    that:
+      - create_cluster_with_special_characters_result.changed is sameas true
+
+- name: Create Cluster with special characters(idempotency check)
+  vmware_cluster:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    datacenter_name: "{{ dc1 }}"
+    cluster_name: 'Cluster\/%'
+    state: present
+  register: create_cluster_with_special_characters_idempotency_check_result
+
+- assert:
+    that:
+      - create_cluster_with_special_characters_idempotency_check_result.changed is sameas false
+
+- name: Delete Cluster with special characters
+  vmware_cluster:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    datacenter_name: "{{ dc1 }}"
+    cluster_name: 'Cluster\/%'
+    state: absent
+  register: delete_cluster_with_special_characters_result
+
+- assert:
+    that:
+      - delete_cluster_with_special_characters_result.changed is sameas true
+
+- name: Delete Cluster with special characters(idempotency check)
+  vmware_cluster:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    datacenter_name: "{{ dc1 }}"
+    cluster_name: 'Cluster\/%'
+    state: absent
+  register: delete_cluster_with_special_characters_idempotency_check_result
+
+- assert:
+    that:
+      - delete_cluster_with_special_characters_idempotency_check_result.changed is sameas false

--- a/tests/integration/targets/vmware_datacenter/tasks/main.yml
+++ b/tests/integration/targets/vmware_datacenter/tasks/main.yml
@@ -48,3 +48,59 @@
     assert:
       that:
         - dc_result_delete.changed
+
+- name: Create Datacenter with special characters
+  vmware_datacenter:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    datacenter_name: 'Datacenter\/%'
+    state: present
+  register: create_datacenter_with_special_characters_result
+
+- assert:
+    that:
+      - create_datacenter_with_special_characters_result.changed is sameas true
+
+- name: Create Datacenter with special characters(idempotency check)
+  vmware_datacenter:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    datacenter_name: 'Datacenter\/%'
+    state: present
+  register: create_datacenter_with_special_characters_idempotency_check_result
+
+- assert:
+    that:
+      - create_datacenter_with_special_characters_idempotency_check_result.changed is sameas false
+
+- name: Delete Datacenter with special characters
+  vmware_datacenter:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    datacenter_name: 'Datacenter\/%'
+    state: absent
+  register: delete_datacenter_with_special_characters_result
+
+- assert:
+    that:
+      - delete_datacenter_with_special_characters_result.changed is sameas true
+
+- name: Delete Datacenter with special characters(idempotency check)
+  vmware_datacenter:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    datacenter_name: 'Datacenter\/%'
+    state: absent
+  register: delete_datacenter_with_special_characters_idempotency_check_result
+
+- assert:
+    that:
+      - delete_datacenter_with_special_characters_idempotency_check_result.changed is sameas false

--- a/tests/integration/targets/vmware_dvs_portgroup/tasks/main.yml
+++ b/tests/integration/targets/vmware_dvs_portgroup/tasks/main.yml
@@ -519,3 +519,113 @@
         state: absent
         switch_name: dvswitch_0001
       register: dvs_result_0001
+
+    - name: Integration test a dvPortGroup name with special characters
+      block:
+        - name: Create dvSwitch with special characters
+          vmware_dvswitch:
+            hostname: "{{ vcenter_hostname }}"
+            username: "{{ vcenter_username }}"
+            password: "{{ vcenter_password }}"
+            validate_certs: false
+            datacenter: "{{ dc1 }}"
+            switch: 'dvSwitch\/%'
+            version: 6.5.0
+            mtu: 9000
+            uplink_quantity: 1
+            state: present
+          register: create_dvswitch_with_special_characters_result
+
+        - assert:
+            that:
+              - create_dvswitch_with_special_characters_result.changed is sameas true
+
+        - name: Create dvPortGroup with special characters
+          vmware_dvs_portgroup:
+            hostname: "{{ vcenter_hostname }}"
+            username: "{{ vcenter_username }}"
+            password: "{{ vcenter_password }}"
+            validate_certs: false
+            switch_name: 'dvSwitch\/%'
+            portgroup_name: 'dvportgroup\/%'
+            vlan_id: 1
+            num_ports: 8
+            portgroup_type: earlyBinding
+            state: present
+          register: create_dvportgroup_with_special_characters_result
+
+        - assert:
+            that:
+              - create_dvportgroup_with_special_characters_result.changed is sameas true
+
+        - name: Create dvPortGroup with special characters(idempotency check)
+          vmware_dvs_portgroup:
+            hostname: "{{ vcenter_hostname }}"
+            username: "{{ vcenter_username }}"
+            password: "{{ vcenter_password }}"
+            validate_certs: false
+            switch_name: 'dvSwitch\/%'
+            portgroup_name: 'dvportgroup\/%'
+            vlan_id: 1
+            num_ports: 8
+            portgroup_type: earlyBinding
+            state: present
+          register: create_dvportgroup_with_special_characters_idempotency_check_result
+
+        - assert:
+            that:
+              - create_dvportgroup_with_special_characters_idempotency_check_result.changed is sameas false
+
+        - name: Delete dvPortGroup with special characters
+          vmware_dvs_portgroup:
+            hostname: "{{ vcenter_hostname }}"
+            username: "{{ vcenter_username }}"
+            password: "{{ vcenter_password }}"
+            validate_certs: false
+            switch_name: 'dvSwitch\/%'
+            portgroup_name: 'dvportgroup\/%'
+            vlan_id: 1
+            num_ports: 8
+            portgroup_type: earlyBinding
+            state: absent
+          register: delete_dvportgroup_with_special_characters_result
+
+        - assert:
+            that:
+              - delete_dvportgroup_with_special_characters_result.changed is sameas true
+
+        - name: Delete dvPortGroup with special characters(idempotency check)
+          vmware_dvs_portgroup:
+            hostname: "{{ vcenter_hostname }}"
+            username: "{{ vcenter_username }}"
+            password: "{{ vcenter_password }}"
+            validate_certs: false
+            switch_name: 'dvSwitch\/%'
+            portgroup_name: 'dvportgroup\/%'
+            vlan_id: 1
+            num_ports: 8
+            portgroup_type: earlyBinding
+            state: absent
+          register: delete_dvportgroup_with_special_characters_idempotency_check_result
+
+        - assert:
+            that:
+              - delete_dvportgroup_with_special_characters_idempotency_check_result.changed is sameas false
+
+        - name: Delete dvSwitch with special characters
+          vmware_dvswitch:
+            hostname: "{{ vcenter_hostname }}"
+            username: "{{ vcenter_username }}"
+            password: "{{ vcenter_password }}"
+            validate_certs: false
+            datacenter: "{{ dc1 }}"
+            switch: 'dvSwitch\/%'
+            version: 6.5.0
+            mtu: 9000
+            uplink_quantity: 1
+            state: absent
+          register: delete_dvswitch_with_special_characters_result
+
+        - assert:
+            that:
+              - delete_dvswitch_with_special_characters_result.changed is sameas true

--- a/tests/integration/targets/vmware_dvswitch/tasks/main.yml
+++ b/tests/integration/targets/vmware_dvswitch/tasks/main.yml
@@ -98,3 +98,75 @@
       that:
         - dvswitch_delete.results[0] is changed
         - dvswitch_delete.results[1] is changed
+
+  - name: Create dvSwitch with special characters
+    vmware_dvswitch:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      validate_certs: false
+      datacenter: "{{ dc1 }}"
+      switch: 'dvSwitch\/%'
+      version: 6.5.0
+      mtu: 9000
+      uplink_quantity: 1
+      state: present
+    register: create_dvswitch_with_special_characters_result
+
+  - assert:
+      that:
+        - create_dvswitch_with_special_characters_result.changed is sameas true
+
+  - name: Create dvSwitch with special characters(idempotency check)
+    vmware_dvswitch:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      validate_certs: false
+      datacenter: "{{ dc1 }}"
+      switch: 'dvSwitch\/%'
+      version: 6.5.0
+      mtu: 9000
+      uplink_quantity: 1
+      state: present
+    register: create_dvswitch_with_special_characters_idempotency_check_result
+
+  - assert:
+      that:
+        - create_dvswitch_with_special_characters_idempotency_check_result.changed is sameas false
+
+  - name: Delete dvSwitch with special characters
+    vmware_dvswitch:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      validate_certs: false
+      datacenter: "{{ dc1 }}"
+      switch: 'dvSwitch\/%'
+      version: 6.5.0
+      mtu: 9000
+      uplink_quantity: 1
+      state: absent
+    register: delete_dvswitch_with_special_characters_result
+
+  - assert:
+      that:
+        - delete_dvswitch_with_special_characters_result.changed is sameas true
+
+  - name: Delete dvSwitch with special characters(idempotency check)
+    vmware_dvswitch:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      validate_certs: false
+      datacenter: "{{ dc1 }}"
+      switch: 'dvSwitch\/%'
+      version: 6.5.0
+      mtu: 9000
+      uplink_quantity: 1
+      state: absent
+    register: delete_dvswitch_with_special_characters_idempotency_check_result
+
+  - assert:
+      that:
+        - delete_dvswitch_with_special_characters_idempotency_check_result.changed is sameas false

--- a/tests/integration/targets/vmware_guest/defaults/main.yml
+++ b/tests/integration/targets/vmware_guest/defaults/main.yml
@@ -31,3 +31,4 @@ vmware_guest_test_playbooks:
   - vapp_d1_c1_f0.yml
   - reconfig_vm_to_latest_version.yml
   - remove_vm_from_inventory.yml
+  - create_vm_using_special_characters.yml

--- a/tests/integration/targets/vmware_guest/tasks/create_vm_using_special_characters.yml
+++ b/tests/integration/targets/vmware_guest/tasks/create_vm_using_special_characters.yml
@@ -1,0 +1,82 @@
+---
+- name: Create VM with special characters
+  vmware_guest:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    datacenter: "{{ dc1 }}"
+    folder: "{{ f0 }}"
+    name: 'test_vm\/%'
+    guest_id: rhel7_64Guest
+    hardware:
+      memory_mb: 512
+      num_cpus: 1
+      scsi: paravirtual
+    disk:
+      - size_gb: 1
+        type: thin
+        datastore: "{{ rw_datastore }}"
+    state: present
+  register: create_vm_with_special_characters_result
+
+- assert:
+    that:
+      - create_vm_with_special_characters_result.changed is sameas true
+
+- name: Create VM with special characters(idempotency check)
+  vmware_guest:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    datacenter: "{{ dc1 }}"
+    folder: "{{ f0 }}"
+    name: 'test_vm\/%'
+    guest_id: rhel7_64Guest
+    hardware:
+      memory_mb: 512
+      num_cpus: 1
+      scsi: paravirtual
+    disk:
+      - size_gb: 1
+        type: thin
+        datastore: "{{ rw_datastore }}"
+    state: present
+  register: create_vm_with_special_characters_idempotency_check_result
+
+- assert:
+    that:
+      - create_vm_with_special_characters_idempotency_check_result.changed is sameas false
+
+- name: Delete VM with special characters
+  vmware_guest:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    datacenter: "{{ dc1 }}"
+    folder: "/vm"
+    name: 'test_vm\/%'
+    state: absent
+  register: delete_vm_with_special_characters_result
+
+- assert:
+    that:
+      - delete_vm_with_special_characters_result.changed is sameas true
+
+- name: Delete VM with special characters(idempotency check)
+  vmware_guest:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    datacenter: "{{ dc1 }}"
+    folder: "/vm"
+    name: 'test_vm\/%'
+    state: absent
+  register: delete_vm_with_special_characters_idempotency_check_result
+
+- assert:
+    that:
+      - delete_vm_with_special_characters_idempotency_check_result.changed is sameas false

--- a/tests/integration/targets/vmware_guest/tasks/create_vm_using_special_characters.yml
+++ b/tests/integration/targets/vmware_guest/tasks/create_vm_using_special_characters.yml
@@ -1,82 +1,84 @@
 ---
-- name: Create VM with special characters
-  vmware_guest:
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    validate_certs: false
-    datacenter: "{{ dc1 }}"
-    folder: "{{ f0 }}"
-    name: 'test_vm\/%'
-    guest_id: rhel7_64Guest
-    hardware:
-      memory_mb: 512
-      num_cpus: 1
-      scsi: paravirtual
-    disk:
-      - size_gb: 1
-        type: thin
-        datastore: "{{ rw_datastore }}"
-    state: present
-  register: create_vm_with_special_characters_result
+- when: vcsim is not defined
+  block:
+    - name: Create VM with special characters
+      vmware_guest:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        datacenter: "{{ dc1 }}"
+        folder: "{{ f0 }}"
+        name: 'test_vm\/%'
+        guest_id: rhel7_64Guest
+        hardware:
+          memory_mb: 512
+          num_cpus: 1
+          scsi: paravirtual
+        disk:
+          - size_gb: 1
+            type: thin
+            datastore: "{{ rw_datastore }}"
+        state: present
+      register: create_vm_with_special_characters_result
 
-- assert:
-    that:
-      - create_vm_with_special_characters_result.changed is sameas true
+    - assert:
+        that:
+          - create_vm_with_special_characters_result.changed is sameas true
 
-- name: Create VM with special characters(idempotency check)
-  vmware_guest:
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    validate_certs: false
-    datacenter: "{{ dc1 }}"
-    folder: "{{ f0 }}"
-    name: 'test_vm\/%'
-    guest_id: rhel7_64Guest
-    hardware:
-      memory_mb: 512
-      num_cpus: 1
-      scsi: paravirtual
-    disk:
-      - size_gb: 1
-        type: thin
-        datastore: "{{ rw_datastore }}"
-    state: present
-  register: create_vm_with_special_characters_idempotency_check_result
+    - name: Create VM with special characters(idempotency check)
+      vmware_guest:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        datacenter: "{{ dc1 }}"
+        folder: "{{ f0 }}"
+        name: 'test_vm\/%'
+        guest_id: rhel7_64Guest
+        hardware:
+          memory_mb: 512
+          num_cpus: 1
+          scsi: paravirtual
+        disk:
+          - size_gb: 1
+            type: thin
+            datastore: "{{ rw_datastore }}"
+        state: present
+      register: create_vm_with_special_characters_idempotency_check_result
 
-- assert:
-    that:
-      - create_vm_with_special_characters_idempotency_check_result.changed is sameas false
+    - assert:
+        that:
+          - create_vm_with_special_characters_idempotency_check_result.changed is sameas false
 
-- name: Delete VM with special characters
-  vmware_guest:
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    validate_certs: false
-    datacenter: "{{ dc1 }}"
-    folder: "/vm"
-    name: 'test_vm\/%'
-    state: absent
-  register: delete_vm_with_special_characters_result
+    - name: Delete VM with special characters
+      vmware_guest:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        datacenter: "{{ dc1 }}"
+        folder: "/vm"
+        name: 'test_vm\/%'
+        state: absent
+      register: delete_vm_with_special_characters_result
 
-- assert:
-    that:
-      - delete_vm_with_special_characters_result.changed is sameas true
+    - assert:
+        that:
+          - delete_vm_with_special_characters_result.changed is sameas true
 
-- name: Delete VM with special characters(idempotency check)
-  vmware_guest:
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    validate_certs: false
-    datacenter: "{{ dc1 }}"
-    folder: "/vm"
-    name: 'test_vm\/%'
-    state: absent
-  register: delete_vm_with_special_characters_idempotency_check_result
+    - name: Delete VM with special characters(idempotency check)
+      vmware_guest:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        datacenter: "{{ dc1 }}"
+        folder: "/vm"
+        name: 'test_vm\/%'
+        state: absent
+      register: delete_vm_with_special_characters_idempotency_check_result
 
-- assert:
-    that:
-      - delete_vm_with_special_characters_idempotency_check_result.changed is sameas false
+    - assert:
+        that:
+          - delete_vm_with_special_characters_idempotency_check_result.changed is sameas false

--- a/tests/integration/targets/vmware_portgroup/tasks/main.yml
+++ b/tests/integration/targets/vmware_portgroup/tasks/main.yml
@@ -71,3 +71,107 @@
     - assert:
         that:
           - pg_info.changed
+
+    - name: Integration test a PortGroup name with special characters
+      block:
+        - name: Create Switch with special characters
+          vmware_vswitch:
+            hostname: "{{ vcenter_hostname }}"
+            username: "{{ vcenter_username }}"
+            password: "{{ vcenter_password }}"
+            validate_certs: false
+            esxi_hostname: "{{ esxi1 }}"
+            switch: 'Switch\/%'
+            state: present
+          register: create_switch_with_special_characters_result
+
+        - assert:
+            that:
+              - create_switch_with_special_characters_result.changed is sameas true
+
+        - name: Create PortGroup with special characters
+          vmware_portgroup:
+            hostname: "{{ vcenter_hostname }}"
+            username: "{{ vcenter_username }}"
+            password: "{{ vcenter_password }}"
+            validate_certs: false
+            hosts: "{{ esxi1 }}"
+            switch: 'Switch\/%'
+            portgroup: 'PortGroup\/%'
+            security:
+              promiscuous_mode: False
+              mac_changes: False
+              forged_transmits: False
+            state: present
+          register: create_portgroup_with_special_characters_result
+
+        - assert:
+            that:
+              - create_portgroup_with_special_characters_result.changed is sameas true
+
+        - name: Create PortGroup with special characters(idempotency check)
+          vmware_portgroup:
+            hostname: "{{ vcenter_hostname }}"
+            username: "{{ vcenter_username }}"
+            password: "{{ vcenter_password }}"
+            validate_certs: false
+            hosts: "{{ esxi1 }}"
+            switch: 'Switch\/%'
+            portgroup: 'PortGroup\/%'
+            security:
+              promiscuous_mode: False
+              mac_changes: False
+              forged_transmits: False
+            state: present
+          register: create_portgroup_with_special_characters_idempotency_check_result
+
+        - assert:
+            that:
+              - create_portgroup_with_special_characters_idempotency_check_result.changed is sameas false
+
+        - name: Delete PortGroup with special characters
+          vmware_portgroup:
+            hostname: "{{ vcenter_hostname }}"
+            username: "{{ vcenter_username }}"
+            password: "{{ vcenter_password }}"
+            validate_certs: false
+            hosts: "{{ esxi1 }}"
+            switch: 'Switch\/%'
+            portgroup: 'PortGroup\/%'
+            state: absent
+          register: delete_portgroup_with_special_characters_result
+
+        - assert:
+            that:
+              - delete_portgroup_with_special_characters_result.changed is sameas true
+
+        - name: Delete PortGroup with special characters(idempotency check)
+          vmware_portgroup:
+            hostname: "{{ vcenter_hostname }}"
+            username: "{{ vcenter_username }}"
+            password: "{{ vcenter_password }}"
+            validate_certs: false
+            hosts: "{{ esxi1 }}"
+            switch: 'Switch\/%'
+            portgroup: 'PortGroup\/%'
+            state: absent
+          register: delete_portgroup_with_special_characters_idempotency_check_result
+
+        - assert:
+            that:
+              - delete_portgroup_with_special_characters_idempotency_check_result.changed is sameas false
+
+        - name: Delete Switch with special characters
+          vmware_vswitch:
+            hostname: "{{ vcenter_hostname }}"
+            username: "{{ vcenter_username }}"
+            password: "{{ vcenter_password }}"
+            validate_certs: false
+            esxi_hostname: "{{ esxi1 }}"
+            switch: 'Switch\/%'
+            state: absent
+          register: delete_switch_with_special_characters_result
+
+        - assert:
+            that:
+              - delete_switch_with_special_characters_result.changed is sameas true

--- a/tests/integration/targets/vmware_vswitch/tasks/main.yml
+++ b/tests/integration/targets/vmware_vswitch/tasks/main.yml
@@ -84,3 +84,59 @@
       - add_vswitch_with_host_system is changed
   always:
   - include_tasks: teardown.yml
+
+  - name: Create Switch with special characters
+    vmware_vswitch:
+      hostname: "{{ esxi1 }}"
+      username: "{{ esxi_user }}"
+      password: "{{ esxi_password }}"
+      validate_certs: false
+      switch: 'Switch\/%'
+      state: present
+    register: create_switch_with_special_characters_result
+
+  - assert:
+      that:
+        - create_switch_with_special_characters_result.changed is sameas true
+
+  - name: Create Switch with special characters(idempotency check)
+    vmware_vswitch:
+      hostname: "{{ esxi1 }}"
+      username: "{{ esxi_user }}"
+      password: "{{ esxi_password }}"
+      validate_certs: false
+      switch: 'Switch\/%'
+      state: present
+    register: create_switch_with_special_characters_idempotency_check_result
+
+  - assert:
+      that:
+        - create_switch_with_special_characters_idempotency_check_result.changed is sameas false
+
+  - name: Delete Switch with special characters
+    vmware_vswitch:
+      hostname: "{{ esxi1 }}"
+      username: "{{ esxi_user }}"
+      password: "{{ esxi_password }}"
+      validate_certs: false
+      switch: 'Switch\/%'
+      state: absent
+    register: delete_switch_with_special_characters_result
+
+  - assert:
+      that:
+        - delete_switch_with_special_characters_result.changed is sameas true
+
+  - name: Delete Switch with special characters(idempotency check)
+    vmware_vswitch:
+      hostname: "{{ esxi1 }}"
+      username: "{{ esxi_user }}"
+      password: "{{ esxi_password }}"
+      validate_certs: false
+      switch: 'Switch\/%'
+      state: absent
+    register: delete_switch_with_special_characters_idempotency_check_result
+
+  - assert:
+      that:
+        - delete_switch_with_special_characters_idempotency_check_result.changed is sameas false


### PR DESCRIPTION
##### SUMMARY

This PR is to fix to support special characters(`/\%`) in an object name.  
The VMware module could create objects with special characters, but could not delete them because it did not perform URL decoding.  
This patch is to modify for comparing an object name with special characters, not URL encoded characters.
But regarding a folder object is not eligible for this patch because it is created with URL-encoded characters because of the specification of vSphere.

related comment: https://github.com/ansible-collections/vmware/pull/366#issuecomment-683956072

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/module_utils/vmware.py

##### ADDITIONAL INFORMATION

tested on vCenter/ESXi 7.0
