### PR TITLE
vmware_vm_inventory: correct docs for requirements

### DIFF
--- a/changelogs/fragments/vmware_vm_inventory_req.yml
+++ b/changelogs/fragments/vmware_vm_inventory_req.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- vmware_vm_inventory - update requirements doc.

--- a/plugins/inventory/vmware_vm_inventory.py
+++ b/plugins/inventory/vmware_vm_inventory.py
@@ -25,7 +25,6 @@ DOCUMENTATION = r'''
       - "PyVmomi"
       - "requests >= 2.3"
       - "vSphere Automation SDK - For tag feature"
-      - "vCloud Suite SDK - For tag feature"
     options:
         hostname:
             description: Name of vCenter or ESXi server.


### PR DESCRIPTION
##### SUMMARY

vCloud Suite SDK dependency was
removed in https://github.com/ansible/ansible/pull/55804
Update documentation for this change.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelogs/fragments/vmware_vm_inventory_req.yml
plugins/inventory/vmware_vm_inventory.py
